### PR TITLE
docs: update README for post-v0.2 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Production-ready volatility surface construction for equity and FX derivatives.
 
 **Surface Construction**
 - **SSVI** global parameterization (Gatheral-Jacquier 2014) with two-stage calibration
+- **eSSVI** extended SSVI (Hendriks-Martini 2019) with tenor-dependent rho, calendar-spread no-arb guarantees, 3-stage calibration from market data
 - **Piecewise** per-tenor surfaces with linear variance interpolation
-- **Builder API** with SVI/SABR/spline model selection
+- **Builder API** with SVI/SABR/spline model selection, dividend yield, per-tenor forward override
 - Ragged strike grids -- different strikes per tenor, no rectangular matrix assumption
 
 **Arbitrage Detection**
@@ -29,8 +30,12 @@ Production-ready volatility surface construction for equity and FX derivatives.
 - Combined `SurfaceDiagnostics` report
 
 **Implied Volatility**
-- Black (lognormal) implied vol via Jackel rational approximation (3 ULP accuracy)
-- Black-Scholes pricing
+- **Black** (lognormal) implied vol via Jackel rational approximation (3 ULP accuracy)
+- **Normal** (Bachelier) implied vol and pricing (Jackel 2017) -- supports negative forwards
+- **Displaced diffusion** -- interpolates between normal (beta=0) and Black (beta=1)
+
+**Local Volatility**
+- **Dupire** local vol extraction (Dupire 1994) from any `VolSurface` via finite differences
 
 **Design**
 - No global state -- evaluation date is a parameter, not a singleton
@@ -113,6 +118,28 @@ let vol = surface.black_vol(0.5, 100.0)?;
 let smile = surface.smile_at(0.5)?;
 ```
 
+### Calibrate eSSVI from market data
+
+```rust
+use volsurf::surface::{EssviSurface, VolSurface};
+
+// Per-tenor (strike, implied_vol) pairs
+let data_3m: Vec<(f64, f64)> = (0..10)
+    .map(|i| (80.0 + 4.0 * i as f64, 0.20 + 0.01 * (i as f64 - 5.0).abs()))
+    .collect();
+let data_1y: Vec<(f64, f64)> = (0..10)
+    .map(|i| (80.0 + 4.0 * i as f64, 0.18 + 0.008 * (i as f64 - 5.0).abs()))
+    .collect();
+
+let surface = EssviSurface::calibrate(
+    &[data_3m, data_1y],
+    &[0.25, 1.0],       // tenors
+    &[100.0, 100.0],    // forwards
+)?;
+
+let vol = surface.black_vol(0.5, 95.0)?;
+```
+
 ### Check for arbitrage
 
 ```rust
@@ -157,8 +184,8 @@ volsurf
 ├── error          VolSurfError, Result<T>
 ├── implied
 │   ├── black      BlackImpliedVol, black_price
-│   ├── normal     NormalImpliedVol (v0.3)
-│   └── displaced  DisplacedImpliedVol (v0.3)
+│   ├── normal     NormalImpliedVol, normal_price
+│   └── displaced  DisplacedImpliedVol, displaced_price
 ├── smile
 │   ├── svi        SviSmile (Gatheral 2006)
 │   ├── sabr       SabrSmile (Hagan 2002)
@@ -166,11 +193,11 @@ volsurf
 │   └── arbitrage  ArbitrageReport, ButterflyViolation
 ├── surface
 │   ├── ssvi       SsviSurface (Gatheral-Jacquier 2014)
-│   ├── essvi      EssviSurface (v0.3)
+│   ├── essvi      EssviSurface, EssviSlice (Hendriks-Martini 2019)
 │   ├── piecewise  PiecewiseSurface (per-tenor interpolation)
 │   ├── builder    SurfaceBuilder, SmileModel
 │   └── arbitrage  SurfaceDiagnostics, CalendarViolation
-├── local_vol      LocalVol trait, DupireLocalVol (v0.3)
+├── local_vol      LocalVol trait, DupireLocalVol (Dupire 1994)
 └── types          Strike, Tenor, Vol, Variance, OptionType
 ```
 
@@ -212,8 +239,9 @@ Measured with Criterion.rs on Apple Silicon. All performance targets exceeded.
 | Version | Name | Key Features |
 |---------|------|--------------|
 | v0.1 | First Light | SVI smile, cubic spline, ragged grid surface, builder API |
-| **v0.2** | **Market Ready** | **SABR, SSVI, calendar arbitrage, surface diagnostics** |
-| v0.3 | Production Grade | eSSVI, Dupire local vol, parallel construction |
+| v0.2 | Market Ready | SABR, SSVI, calendar arbitrage, surface diagnostics |
+| **v0.2.1** | | **eSSVI surface + calibration, Normal/Displaced IV, Dupire local vol** |
+| v0.3 | Production Grade | Parallel construction, benchmark validation |
 | v1.0 | Stable | API stability, PyO3 bindings, WASM target |
 
 ## References
@@ -223,6 +251,9 @@ Measured with Criterion.rs on Apple Silicon. All performance targets exceeded.
 - Hagan, P. et al. "Managing Smile Risk", *Wilmott* (2002)
 - Jackel, P. "Let's Be Rational" (2013)
 - Zeliade Systems, "Quasi-Explicit Calibration of Gatheral's SVI Model" (2009)
+- Hendriks, S. & Martini, C. "The Extended SSVI Volatility Surface" (2019)
+- Dupire, B. "Pricing with a Smile", *Risk* (1994)
+- Jackel, P. "Implied Normal Volatility" (2017)
 - Breeden, D.T. & Litzenberger, R.H. "Prices of State-Contingent Claims Implicit in Option Prices" (1978)
 
 ## License


### PR DESCRIPTION
## Summary

- Add eSSVI surface + calibration, Normal/Displaced IV, Dupire local vol, dividend yield, and forward override to Features section
- Remove stale `(v0.3)` tags from architecture tree for all shipped items
- Add eSSVI calibrate Quick Start example
- Update roadmap: v0.2.1 row for shipped features, slim v0.3 to remaining work
- Add 3 references: Hendriks-Martini 2019, Dupire 1994, Jäckel 2017

## Test plan

- [x] All 811 tests + 21 doctests pass
- [x] Zero clippy warnings
- [ ] Verify rendered markdown on GitHub PR preview