### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in volsurf, please report it privately via
+[GitHub Security Advisories](https://github.com/volsurf-rs/volsurf/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.
+
+## Supported Versions
+
+Only the latest published version on [crates.io](https://crates.io/crates/volsurf) receives security fixes.


### PR DESCRIPTION
## Summary

- Add SECURITY.md with private vulnerability reporting via GitHub Security Advisories
- Points reporters to advisory flow instead of public issues

## Test plan

- [x] No code changes — docs only