### PR TITLE
fix: better error when calibration produces non-monotone thetas

### DIFF
--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -534,6 +534,24 @@ impl EssviSurface {
             rhos.push(svi.rho());
         }
 
+        for (i, w) in thetas.windows(2).enumerate() {
+            if w[1] <= w[0] {
+                return Err(VolSurfError::CalibrationError {
+                    message: format!(
+                        "per-tenor SVI calibration produced non-monotone ATM variances: \
+                         theta[{i}]={:.6} >= theta[{}]={:.6} (tenors {}, {})",
+                        w[0],
+                        i + 1,
+                        w[1],
+                        tenors[i],
+                        tenors[i + 1]
+                    ),
+                    model: "eSSVI",
+                    rms_error: None,
+                });
+            }
+        }
+
         let theta_max = *thetas.last().unwrap();
         let xs: Vec<f64> = thetas.iter().map(|&t| t / theta_max).collect();
 
@@ -2225,6 +2243,31 @@ mod tests {
         ];
         let result = EssviSurface::calibrate(&data, &[0.0, 1.0], &[100.0, 100.0]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn calibrate_rejects_non_monotone_thetas() {
+        // Earnings-like scenario: short tenor has inflated vol → theta[0] > theta[1].
+        // ATM vol 50% at T=0.25 gives theta ~= 0.0625, but ATM vol 20% at T=0.5 gives theta ~= 0.02.
+        let make_smile = |fwd: f64, atm_vol: f64| -> Vec<(f64, f64)> {
+            let strikes: Vec<f64> = (0..10).map(|i| fwd * (0.85 + 0.03 * i as f64)).collect();
+            strikes
+                .iter()
+                .map(|&k| {
+                    let m = ((k / fwd).ln()).abs();
+                    (k, atm_vol + 0.3 * m)
+                })
+                .collect()
+        };
+        let data = vec![make_smile(100.0, 0.50), make_smile(100.0, 0.20)];
+        let result = EssviSurface::calibrate(&data, &[0.25, 0.50], &[100.0, 100.0]);
+        let err = result.unwrap_err();
+        assert!(matches!(err, VolSurfError::CalibrationError { .. }));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-monotone"),
+            "error should mention non-monotone: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add explicit monotonicity check after Stage 1 per-tenor SVI calibration in both `SsviSurface::calibrate()` and `EssviSurface::calibrate()`
- Return `CalibrationError` with tenor indices, theta values, and tenor times instead of letting the constructor reject with generic `InvalidInput`

Closes #19

## Problem
Per-tenor SVI calibration can produce non-monotone ATM variances (e.g. earnings event inflating short-tenor vol). Previously the constructor rejected with `InvalidInput { "thetas must be strictly increasing" }` — giving no indication that calibration produced the bad thetas or which tenors are problematic.

## Changes
- `src/surface/ssvi.rs`: monotonicity check after Stage 1 loop, returns `CalibrationError` with diagnostics
- `src/surface/essvi.rs`: identical check with `model: "eSSVI"`
- 2 new tests using earnings-like market data (ATM vol 50% short tenor vs 20% long tenor)

## Example error message
```
per-tenor SVI calibration produced non-monotone ATM variances:
theta[0]=0.062500 >= theta[1]=0.020000 (tenors 0.25, 0.5)
```

## Test plan
- [x] 2 new tests: `calibrate_rejects_non_monotone_thetas` (SSVI + eSSVI)
- [x] Tests verify `CalibrationError` variant (not `InvalidInput`)
- [x] Tests verify "non-monotone" in error message
- [x] Full suite: 817 tests passing (724 unit + 45 integration + 10 proptest + 17 hendriks + 21 doctest)
- [x] Zero clippy warnings