### PR TITLE
feat: validate inputs in moneyness and forward_price functions

### DIFF
--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -6,6 +6,9 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::error;
+use crate::validate::{validate_finite, validate_non_negative, validate_positive};
+
 /// Stickiness convention for the volatility surface.
 ///
 /// - **Sticky strike**: vol at a fixed strike stays constant as spot moves.
@@ -21,18 +24,33 @@ pub enum StickyKind {
 }
 
 /// Convert a strike to log-moneyness: k = ln(K / F).
-pub fn log_moneyness(strike: f64, forward: f64) -> f64 {
-    (strike / forward).ln()
+///
+/// Returns `Err` if `strike` or `forward` is non-positive, NaN, or infinite.
+pub fn log_moneyness(strike: f64, forward: f64) -> error::Result<f64> {
+    validate_positive(strike, "strike")?;
+    validate_positive(forward, "forward")?;
+    Ok((strike / forward).ln())
 }
 
 /// Convert a strike to simple moneyness: m = K / F.
-pub fn moneyness(strike: f64, forward: f64) -> f64 {
-    strike / forward
+///
+/// Returns `Err` if `strike` or `forward` is non-positive, NaN, or infinite.
+pub fn moneyness(strike: f64, forward: f64) -> error::Result<f64> {
+    validate_positive(strike, "strike")?;
+    validate_positive(forward, "forward")?;
+    Ok(strike / forward)
 }
 
 /// Compute forward price from spot: F = S · exp((r − q) · T).
-pub fn forward_price(spot: f64, rate: f64, dividend_yield: f64, expiry: f64) -> f64 {
-    spot * ((rate - dividend_yield) * expiry).exp()
+///
+/// Returns `Err` if `spot` is non-positive, `rate` or `dividend_yield` is
+/// non-finite, or `expiry` is negative.
+pub fn forward_price(spot: f64, rate: f64, dividend_yield: f64, expiry: f64) -> error::Result<f64> {
+    validate_positive(spot, "spot")?;
+    validate_finite(rate, "rate")?;
+    validate_finite(dividend_yield, "dividend_yield")?;
+    validate_non_negative(expiry, "expiry")?;
+    Ok(spot * ((rate - dividend_yield) * expiry).exp())
 }
 
 #[cfg(test)]
@@ -43,7 +61,7 @@ mod tests {
     #[test]
     fn forward_price_known_value() {
         // spot=100, rate=0.05, q=0, expiry=1.0 → F = 100 * e^0.05 ≈ 105.127
-        let f = forward_price(100.0, 0.05, 0.0, 1.0);
+        let f = forward_price(100.0, 0.05, 0.0, 1.0).unwrap();
         let expected = 100.0 * (0.05_f64).exp();
         assert_abs_diff_eq!(f, expected, epsilon = 1e-10);
         assert_abs_diff_eq!(f, 105.127109637602, epsilon = 1e-10);
@@ -52,14 +70,14 @@ mod tests {
     #[test]
     fn forward_price_zero_rate() {
         // Zero rate, zero yield → forward equals spot
-        let f = forward_price(100.0, 0.0, 0.0, 1.0);
+        let f = forward_price(100.0, 0.0, 0.0, 1.0).unwrap();
         assert_abs_diff_eq!(f, 100.0, epsilon = 1e-10);
     }
 
     #[test]
     fn forward_price_negative_rate() {
         // Negative rate → forward < spot (inverted curve)
-        let f = forward_price(100.0, -0.02, 0.0, 1.0);
+        let f = forward_price(100.0, -0.02, 0.0, 1.0).unwrap();
         let expected = 100.0 * (-0.02_f64).exp();
         assert_abs_diff_eq!(f, expected, epsilon = 1e-10);
         assert!(f < 100.0, "negative rate should produce forward < spot");
@@ -68,15 +86,15 @@ mod tests {
     #[test]
     fn forward_price_zero_expiry() {
         // Zero expiry → forward equals spot regardless of rate
-        let f = forward_price(100.0, 0.05, 0.0, 0.0);
+        let f = forward_price(100.0, 0.05, 0.0, 0.0).unwrap();
         assert_abs_diff_eq!(f, 100.0, epsilon = 1e-10);
     }
 
     #[test]
     fn forward_price_scales_with_expiry() {
         // Doubling expiry should compound the rate effect
-        let f1 = forward_price(100.0, 0.05, 0.0, 1.0);
-        let f2 = forward_price(100.0, 0.05, 0.0, 2.0);
+        let f1 = forward_price(100.0, 0.05, 0.0, 1.0).unwrap();
+        let f2 = forward_price(100.0, 0.05, 0.0, 2.0).unwrap();
         let expected_ratio = (0.05_f64).exp();
         assert_abs_diff_eq!(f2 / f1, expected_ratio, epsilon = 1e-10);
     }
@@ -84,14 +102,14 @@ mod tests {
     #[test]
     fn log_moneyness_atm() {
         // ATM: strike == forward → k = ln(1) = 0
-        let k = log_moneyness(100.0, 100.0);
+        let k = log_moneyness(100.0, 100.0).unwrap();
         assert_abs_diff_eq!(k, 0.0, epsilon = 1e-10);
     }
 
     #[test]
     fn log_moneyness_itm_call() {
         // Strike < forward → k < 0
-        let k = log_moneyness(95.0, 100.0);
+        let k = log_moneyness(95.0, 100.0).unwrap();
         let expected = (95.0_f64 / 100.0).ln();
         assert_abs_diff_eq!(k, expected, epsilon = 1e-10);
         assert!(k < 0.0, "ITM call should have negative log-moneyness");
@@ -100,7 +118,7 @@ mod tests {
     #[test]
     fn log_moneyness_otm_call() {
         // Strike > forward → k > 0
-        let k = log_moneyness(110.0, 100.0);
+        let k = log_moneyness(110.0, 100.0).unwrap();
         let expected = (110.0_f64 / 100.0).ln();
         assert_abs_diff_eq!(k, expected, epsilon = 1e-10);
         assert!(k > 0.0, "OTM call should have positive log-moneyness");
@@ -109,22 +127,22 @@ mod tests {
     #[test]
     fn log_moneyness_symmetry() {
         // k(K/F) = -k(F/K)
-        let k1 = log_moneyness(120.0, 100.0);
-        let k2 = log_moneyness(100.0, 120.0);
+        let k1 = log_moneyness(120.0, 100.0).unwrap();
+        let k2 = log_moneyness(100.0, 120.0).unwrap();
         assert_abs_diff_eq!(k1, -k2, epsilon = 1e-10);
     }
 
     #[test]
     fn moneyness_atm() {
         // ATM: strike/forward = 1.0
-        let m = moneyness(100.0, 100.0);
+        let m = moneyness(100.0, 100.0).unwrap();
         assert_abs_diff_eq!(m, 1.0, epsilon = 1e-10);
     }
 
     #[test]
     fn moneyness_itm_call() {
         // Strike < forward → m < 1.0
-        let m = moneyness(80.0, 100.0);
+        let m = moneyness(80.0, 100.0).unwrap();
         assert_abs_diff_eq!(m, 0.8, epsilon = 1e-10);
         assert!(m < 1.0, "ITM call should have moneyness < 1");
     }
@@ -132,7 +150,7 @@ mod tests {
     #[test]
     fn moneyness_otm_call() {
         // Strike > forward → m > 1.0
-        let m = moneyness(120.0, 100.0);
+        let m = moneyness(120.0, 100.0).unwrap();
         assert_abs_diff_eq!(m, 1.2, epsilon = 1e-10);
         assert!(m > 1.0, "OTM call should have moneyness > 1");
     }
@@ -142,112 +160,175 @@ mod tests {
         // m = exp(k)
         let strike = 110.0;
         let forward = 100.0;
-        let k = log_moneyness(strike, forward);
-        let m = moneyness(strike, forward);
+        let k = log_moneyness(strike, forward).unwrap();
+        let m = moneyness(strike, forward).unwrap();
         assert_abs_diff_eq!(m, k.exp(), epsilon = 1e-10);
     }
 
     #[test]
     fn moneyness_consistency() {
         // moneyness(K, F) * moneyness(F, K) = 1
-        let m1 = moneyness(120.0, 100.0);
-        let m2 = moneyness(100.0, 120.0);
+        let m1 = moneyness(120.0, 100.0).unwrap();
+        let m2 = moneyness(100.0, 120.0).unwrap();
         assert_abs_diff_eq!(m1 * m2, 1.0, epsilon = 1e-10);
     }
 
-    // Gap #3: log_moneyness/moneyness with zero forward
-
     #[test]
-    fn log_moneyness_zero_forward_returns_inf() {
-        let k = log_moneyness(100.0, 0.0);
-        assert!(
-            k.is_infinite(),
-            "log_moneyness(100, 0) should be Inf, got {k}"
-        );
-        assert!(k.is_sign_positive());
+    fn log_moneyness_zero_forward_returns_err() {
+        assert!(log_moneyness(100.0, 0.0).is_err());
     }
 
     #[test]
-    fn moneyness_zero_forward_returns_inf() {
-        let m = moneyness(100.0, 0.0);
-        assert!(m.is_infinite(), "moneyness(100, 0) should be Inf, got {m}");
+    fn moneyness_zero_forward_returns_err() {
+        assert!(moneyness(100.0, 0.0).is_err());
     }
 
     #[test]
-    fn log_moneyness_zero_strike_returns_neg_inf() {
-        let k = log_moneyness(0.0, 100.0);
-        assert!(
-            k.is_infinite() && k.is_sign_negative(),
-            "log_moneyness(0, 100) should be -Inf, got {k}"
-        );
+    fn log_moneyness_zero_strike_returns_err() {
+        assert!(log_moneyness(0.0, 100.0).is_err());
     }
 
     #[test]
-    fn moneyness_zero_strike_returns_zero() {
-        let m = moneyness(0.0, 100.0);
-        assert_abs_diff_eq!(m, 0.0, epsilon = 1e-15);
-    }
-
-    // Gap #4: NaN and Inf inputs
-
-    #[test]
-    fn log_moneyness_nan_strike_returns_nan() {
-        let k = log_moneyness(f64::NAN, 100.0);
-        assert!(k.is_nan(), "log_moneyness(NaN, 100) should be NaN, got {k}");
+    fn moneyness_zero_strike_returns_err() {
+        assert!(moneyness(0.0, 100.0).is_err());
     }
 
     #[test]
-    fn log_moneyness_nan_forward_returns_nan() {
-        let k = log_moneyness(100.0, f64::NAN);
-        assert!(k.is_nan(), "log_moneyness(100, NaN) should be NaN, got {k}");
+    fn log_moneyness_nan_returns_err() {
+        assert!(log_moneyness(f64::NAN, 100.0).is_err());
+        assert!(log_moneyness(100.0, f64::NAN).is_err());
     }
 
     #[test]
-    fn moneyness_nan_inputs_return_nan() {
-        assert!(moneyness(f64::NAN, 100.0).is_nan());
-        assert!(moneyness(100.0, f64::NAN).is_nan());
+    fn moneyness_nan_returns_err() {
+        assert!(moneyness(f64::NAN, 100.0).is_err());
+        assert!(moneyness(100.0, f64::NAN).is_err());
     }
 
     #[test]
-    fn log_moneyness_inf_strike_returns_inf() {
-        let k = log_moneyness(f64::INFINITY, 100.0);
-        assert!(k.is_infinite() && k.is_sign_positive());
+    fn log_moneyness_inf_returns_err() {
+        assert!(log_moneyness(f64::INFINITY, 100.0).is_err());
+        assert!(log_moneyness(100.0, f64::INFINITY).is_err());
+        assert!(log_moneyness(f64::NEG_INFINITY, 100.0).is_err());
+        assert!(log_moneyness(100.0, f64::NEG_INFINITY).is_err());
     }
 
     #[test]
-    fn moneyness_inf_strike_returns_inf() {
-        let m = moneyness(f64::INFINITY, 100.0);
+    fn moneyness_inf_returns_err() {
+        assert!(moneyness(f64::INFINITY, 100.0).is_err());
+        assert!(moneyness(100.0, f64::INFINITY).is_err());
+        assert!(moneyness(f64::NEG_INFINITY, 100.0).is_err());
+        assert!(moneyness(100.0, f64::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn forward_price_non_finite_returns_err() {
+        assert!(forward_price(f64::NAN, 0.05, 0.0, 1.0).is_err());
+        assert!(forward_price(100.0, f64::NAN, 0.0, 1.0).is_err());
+        assert!(forward_price(100.0, 0.05, f64::NAN, 1.0).is_err());
+        assert!(forward_price(100.0, 0.05, 0.0, f64::NAN).is_err());
+        assert!(forward_price(f64::INFINITY, 0.05, 0.0, 1.0).is_err());
+        assert!(forward_price(100.0, f64::INFINITY, 0.0, 1.0).is_err());
+        assert!(forward_price(100.0, 0.05, f64::NEG_INFINITY, 1.0).is_err());
+        assert!(forward_price(100.0, 0.05, 0.0, f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn forward_price_negative_expiry_returns_err() {
+        assert!(forward_price(100.0, 0.05, 0.0, -1.0).is_err());
+    }
+
+    #[test]
+    fn forward_price_zero_spot_returns_err() {
+        assert!(forward_price(0.0, 0.05, 0.0, 1.0).is_err());
+    }
+
+    #[test]
+    fn log_moneyness_negative_strike_returns_err() {
+        assert!(log_moneyness(-50.0, 100.0).is_err());
+    }
+
+    #[test]
+    fn log_moneyness_negative_forward_returns_err() {
+        assert!(log_moneyness(100.0, -50.0).is_err());
+    }
+
+    #[test]
+    fn moneyness_negative_strike_returns_err() {
+        assert!(moneyness(-50.0, 100.0).is_err());
+    }
+
+    #[test]
+    fn moneyness_negative_forward_returns_err() {
+        assert!(moneyness(100.0, -50.0).is_err());
+    }
+
+    #[test]
+    fn forward_price_negative_spot_returns_err() {
+        assert!(forward_price(-100.0, 0.05, 0.0, 1.0).is_err());
+    }
+
+    #[test]
+    fn log_moneyness_error_is_invalid_input() {
+        use crate::error::VolSurfError;
+        let err = log_moneyness(100.0, 0.0).unwrap_err();
+        assert!(matches!(err, VolSurfError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn moneyness_error_is_invalid_input() {
+        use crate::error::VolSurfError;
+        let err = moneyness(f64::NAN, 100.0).unwrap_err();
+        assert!(matches!(err, VolSurfError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn forward_price_error_is_invalid_input() {
+        use crate::error::VolSurfError;
+        let err = forward_price(100.0, 0.05, 0.0, -1.0).unwrap_err();
+        assert!(matches!(err, VolSurfError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn log_moneyness_large_finite_values_succeed() {
+        let k = log_moneyness(1e300, 1e300).unwrap();
+        assert_abs_diff_eq!(k, 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn moneyness_large_finite_values_succeed() {
+        let m = moneyness(1e300, 1e300).unwrap();
+        assert_abs_diff_eq!(m, 1.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn moneyness_extreme_ratio_overflows() {
+        // Both inputs valid (positive, finite), but ratio overflows to Inf.
+        // Documents current behavior: input guards don't catch output overflow.
+        let m = moneyness(100.0, f64::MIN_POSITIVE).unwrap();
         assert!(m.is_infinite());
-    }
-
-    #[test]
-    fn forward_price_nan_inputs() {
-        assert!(forward_price(f64::NAN, 0.05, 0.0, 1.0).is_nan());
-        assert!(forward_price(100.0, f64::NAN, 0.0, 1.0).is_nan());
-        assert!(forward_price(100.0, 0.05, f64::NAN, 1.0).is_nan());
-        assert!(forward_price(100.0, 0.05, 0.0, f64::NAN).is_nan());
     }
 
     #[test]
     fn forward_price_positive_dividend_yield() {
         // r=0.05, q=0.02 → F = 100 * exp(0.03) ≈ 103.045
-        let f = forward_price(100.0, 0.05, 0.02, 1.0);
+        let f = forward_price(100.0, 0.05, 0.02, 1.0).unwrap();
         let expected = 100.0 * (0.03_f64).exp();
         assert_abs_diff_eq!(f, expected, epsilon = 1e-10);
-        assert!(f < forward_price(100.0, 0.05, 0.0, 1.0));
+        assert!(f < forward_price(100.0, 0.05, 0.0, 1.0).unwrap());
     }
 
     #[test]
     fn forward_price_yield_equals_rate() {
         // r = q → cost of carry is zero → F = S
-        let f = forward_price(100.0, 0.05, 0.05, 1.0);
+        let f = forward_price(100.0, 0.05, 0.05, 1.0).unwrap();
         assert_abs_diff_eq!(f, 100.0, epsilon = 1e-10);
     }
 
     #[test]
     fn forward_price_yield_exceeds_rate() {
         // q > r → forward < spot (high-dividend stock)
-        let f = forward_price(100.0, 0.03, 0.05, 1.0);
+        let f = forward_price(100.0, 0.03, 0.05, 1.0).unwrap();
         let expected = 100.0 * (-0.02_f64).exp();
         assert_abs_diff_eq!(f, expected, epsilon = 1e-10);
         assert!(f < 100.0);
@@ -256,10 +337,10 @@ mod tests {
     #[test]
     fn forward_price_negative_dividend_yield() {
         // Negative q (e.g. convenience yield on commodity) → higher forward
-        let f = forward_price(100.0, 0.05, -0.02, 1.0);
+        let f = forward_price(100.0, 0.05, -0.02, 1.0).unwrap();
         let expected = 100.0 * (0.07_f64).exp();
         assert_abs_diff_eq!(f, expected, epsilon = 1e-10);
-        assert!(f > forward_price(100.0, 0.05, 0.0, 1.0));
+        assert!(f > forward_price(100.0, 0.05, 0.0, 1.0).unwrap());
     }
 
     // Gap #5: StickyKind enum

--- a/src/surface/builder.rs
+++ b/src/surface/builder.rs
@@ -262,9 +262,10 @@ impl SurfaceBuilder {
                 if let Some(fwd) = tenor.forward {
                     validate_positive(fwd, "per-tenor forward")?;
                 }
-                let forward = tenor
-                    .forward
-                    .unwrap_or_else(|| conventions::forward_price(spot, rate, q, tenor.expiry));
+                let forward = match tenor.forward {
+                    Some(fwd) => fwd,
+                    None => conventions::forward_price(spot, rate, q, tenor.expiry)?,
+                };
 
                 let smile: Box<dyn SmileSection> = match model {
                     SmileModel::Svi => {


### PR DESCRIPTION
## Summary

- `log_moneyness`, `moneyness`, and `forward_price` in `conventions.rs` now return `Result<f64>` instead of bare `f64`
- Non-positive, NaN, and infinite inputs produce `Err(InvalidInput)` instead of silently returning Inf/NaN
- Both production callers updated: `DupireLocalVol::local_vol` (added `?`) and `SurfaceBuilder::build` (replaced `unwrap_or_else` with `match`)

## Test plan

- [x] 834 tests pass (was 818), zero clippy warnings
- [x] 45 conventions tests: 18 happy-path with `.unwrap()`, 10 error-case flipped to `is_err()`, 5 negative-input guards, 3 variant assertions, 2 large-finite, 1 subnormal overflow doc, 6 original StickyKind
- [x] 1 Dupire integration test: stub surface with `forward()=0.0` propagates `InvalidInput`
- [x] 3 new proptests: `exp(log_moneyness)==moneyness`, positive inputs always succeed, `forward_price` positive+finite

Closes #10