### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Production-ready volatility surface library for derivatives pricing"


### PR DESCRIPTION
## Summary

- Version bump to 0.4.0 following v0.4 hardening merge (#35)

## Test plan

- [x] Single-line Cargo.toml change — CI will validate