### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Production-ready volatility surface library for derivatives pricing"


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version from `0.4.0` to `1.0.0` to match the v1.0.0 tag

## Test plan

- [x] One-line change, no code affected
- [ ] CI passes