### PR TITLE
fix: store actual density in SVI ButterflyViolation (#46)

### DIFF
--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -842,6 +842,15 @@ mod tests {
     }
 
     #[test]
+    fn is_arbitrage_free_skips_density_errors() {
+        // make_invalid_svi has w < 0 everywhere, so g = NEG_INFINITY at all
+        // grid points but density() returns Err — violations get skipped.
+        let smile = make_invalid_svi();
+        let report = smile.is_arbitrage_free().unwrap();
+        assert!(report.butterfly_violations.is_empty());
+    }
+
+    #[test]
     fn flat_smile_is_arb_free() {
         let smile = SviSmile::new(100.0, 1.0, 0.04, 0.0, 0.0, 0.0, 0.1).unwrap();
         let report = smile.is_arbitrage_free().unwrap();


### PR DESCRIPTION
## Summary

- SVI's `is_arbitrage_free()` was storing the raw g-function value `g(k)` in `ButterflyViolation.density`, while SABR and SplineSmile stored the actual risk-neutral density `q(K)`. This made cross-model comparison of violation severity meaningless.
- Now computes `q(K) = g(k)·n(d₂)/(K·√w)` via `self.density(strike)` on violation points, matching the documented contract and other models.
- When `density()` returns `Err` (degenerate `w ≤ 0`), the violation is skipped (`continue`), matching SABR's pattern.

## Changes

- `src/smile/svi.rs` — `is_arbitrage_free()`: call `self.density(strike)` instead of storing `g` directly
- `src/smile/svi.rs` — 2 new tests: density consistency + `Err` path coverage

## Test plan

- [x] 861 tests pass (765 unit + 96 integration/proptest/doc/compat)
- [x] `violation_density_matches_density_method` — each violation's density equals `self.density(strike)`
- [x] `is_arbitrage_free_skips_density_errors` — `w ≤ 0` edge case handled
- [x] Existing `violated_params_detect_violations` still passes (sign preserved)
- [x] Zero clippy warnings, clean formatting, docs build

Closes #46