### PR TITLE
fix: store actual density in SsviSlice/EssviSlice ButterflyViolation (#70)

### DIFF
--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -1089,6 +1089,18 @@ mod tests {
     }
 
     #[test]
+    fn violation_density_matches_density_method() {
+        let s = EssviSlice::new(100.0, 1.0, -0.95, 3.0, 0.5, 0.16).unwrap();
+        let report = s.is_arbitrage_free().unwrap();
+        assert!(!report.butterfly_violations.is_empty());
+        for v in &report.butterfly_violations {
+            let expected = s.density(v.strike).unwrap();
+            assert_abs_diff_eq!(v.density, expected, epsilon = 1e-14);
+            assert_abs_diff_eq!(v.magnitude, expected.abs(), epsilon = 1e-14);
+        }
+    }
+
+    #[test]
     fn is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<EssviSlice>();


### PR DESCRIPTION
## Summary

- `SsviSlice::is_arbitrage_free()` stored the raw g-function value in `ButterflyViolation.density` instead of the actual risk-neutral density q(K). Same bug as #46 but for SSVI/eSSVI.
- Added analytical `density()` override to `SsviSlice` using q(K) = g(k)·n(d₂)/(K·√w), matching SVI's implementation.
- Fixed `is_arbitrage_free()` to call `self.density(strike)` on violation points with `Err(_) => continue`.
- Added `density()` delegation to `EssviSlice` (was falling through to slow Breeden-Litzenberger default).

## Changes

- `src/surface/ssvi.rs` — analytical `density()` override + `is_arbitrage_free()` fix + 2 tests
- `src/surface/essvi.rs` — `density()` delegation + 1 test

## Test plan

- [x] 864 tests pass (768 unit + 96 integration/proptest/doc/compat)
- [x] `slice_violation_density_matches_density_method` — SsviSlice violations match `self.density(strike)`
- [x] `slice_density_cross_check_breeden_litzenberger` — analytical agrees with numerical within 1e-4
- [x] `violation_density_matches_density_method` (eSSVI) — EssviSlice delegation works end-to-end
- [x] Zero clippy warnings, clean formatting, docs build

Closes #70