### PR TITLE
feat: expose EssviSurface.calibrate() in PyO3 bindings

### DIFF
--- a/python/src/surface.rs
+++ b/python/src/surface.rs
@@ -226,6 +226,17 @@ impl PyEssviSurface {
             serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))?;
         Ok(Self { inner })
     }
+
+    #[staticmethod]
+    #[pyo3(signature = (market_data, tenors, forwards))]
+    fn calibrate(
+        market_data: Vec<Vec<(f64, f64)>>,
+        tenors: Vec<f64>,
+        forwards: Vec<f64>,
+    ) -> PyResult<Self> {
+        let inner = EssviSurface::calibrate(&market_data, &tenors, &forwards).map_err(to_py_err)?;
+        Ok(Self { inner })
+    }
 }
 
 impl_vol_grid!(PyEssviSurface);


### PR DESCRIPTION
## Summary
- Exposes `EssviSurface::calibrate()` as a `@staticmethod` on the Python `EssviSurface` class
- Delegates to the existing Rust 3-stage calibrator (Hendriks-Martini 2019): per-tenor SVI → ρ(θ) curve fit → η/γ global optimization
- Accepts `list[list[tuple[float, float]]]` market data (per-tenor strike/IV pairs)

## Usage
```python
surface = EssviSurface.calibrate(
    market_data,  # list of per-tenor [(strike, iv), ...] pairs
    tenors,       # [0.25, 0.5, 1.0, ...]
    forwards,     # [100.0, 100.0, ...]
)
```

## Test plan
- [x] `cargo check -p volsurf-python` — compiles clean
- [x] 207 existing Python tests pass
- [x] Manual smoke test: calibrates 3-tenor synthetic data, produces valid surface
- [x] Error propagation verified (< 2 tenors, length mismatch)
- [ ] CI (Tests, Clippy, Formatting, Documentation)