### PR TITLE
feat: two-stage eSSVI calibration API (#88)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -35,6 +35,7 @@ fn volsurf(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<implied::PyNormalImpliedVol>()?;
     m.add_class::<implied::PyDisplacedImpliedVol>()?;
     m.add_class::<PySsviSurface>()?;
+    m.add_class::<PyPerTenorFit>()?;
     m.add_class::<PyEssviSurface>()?;
     m.add_class::<PySurfaceBuilder>()?;
     m.add_class::<PyDupireLocalVol>()?;

--- a/python/src/smile.rs
+++ b/python/src/smile.rs
@@ -72,6 +72,12 @@ pub struct PySviSmile {
     inner: SviSmile,
 }
 
+impl PySviSmile {
+    pub(crate) fn from_inner(inner: SviSmile) -> Self {
+        Self { inner }
+    }
+}
+
 #[pymethods]
 impl PySviSmile {
     #[new]

--- a/python/src/surface.rs
+++ b/python/src/surface.rs
@@ -4,7 +4,7 @@ use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use volsurf::VolSurface;
-use volsurf::surface::{EssviSurface, SsviSurface, SurfaceBuilder};
+use volsurf::surface::{EssviSurface, PerTenorFit, SsviSurface, SurfaceBuilder};
 
 use crate::error::to_py_err;
 use crate::types::{PySmile, PySmileModel, PySurface, PySurfaceDiagnostics};
@@ -138,6 +138,44 @@ impl PySsviSurface {
 
 impl_vol_grid!(PySsviSurface);
 
+#[pyclass(frozen, name = "PerTenorFit")]
+pub struct PyPerTenorFit {
+    inner: PerTenorFit,
+}
+
+#[pymethods]
+impl PyPerTenorFit {
+    #[getter]
+    fn tenor(&self) -> f64 {
+        self.inner.tenor
+    }
+
+    #[getter]
+    fn forward(&self) -> f64 {
+        self.inner.forward
+    }
+
+    #[getter]
+    fn theta(&self) -> f64 {
+        self.inner.theta
+    }
+
+    #[getter]
+    fn rms_error(&self) -> f64 {
+        self.inner.rms_error
+    }
+
+    #[getter]
+    fn svi(&self) -> crate::smile::PySviSmile {
+        crate::smile::PySviSmile::from_inner(self.inner.svi.clone())
+    }
+
+    #[getter]
+    fn market_data(&self) -> Vec<(f64, f64)> {
+        self.inner.market_data.clone()
+    }
+}
+
 #[pyclass(frozen, name = "EssviSurface")]
 pub struct PyEssviSurface {
     inner: EssviSurface,
@@ -246,6 +284,29 @@ impl PyEssviSurface {
         forwards: Vec<f64>,
     ) -> PyResult<Self> {
         let inner = EssviSurface::calibrate(&market_data, &tenors, &forwards).map_err(to_py_err)?;
+        Ok(Self { inner })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (market_data, tenors, forwards))]
+    fn fit_per_tenor(
+        market_data: Vec<Vec<(f64, f64)>>,
+        tenors: Vec<f64>,
+        forwards: Vec<f64>,
+    ) -> PyResult<Vec<PyPerTenorFit>> {
+        let fits =
+            EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).map_err(to_py_err)?;
+        Ok(fits
+            .into_iter()
+            .map(|f| PyPerTenorFit { inner: f })
+            .collect())
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (fits))]
+    fn from_per_tenor(fits: Vec<PyRef<'_, PyPerTenorFit>>) -> PyResult<Self> {
+        let inner_fits: Vec<PerTenorFit> = fits.iter().map(|f| f.inner.clone()).collect();
+        let inner = EssviSurface::from_per_tenor(&inner_fits).map_err(to_py_err)?;
         Ok(Self { inner })
     }
 }

--- a/python/tests/test_surface.py
+++ b/python/tests/test_surface.py
@@ -5,6 +5,7 @@ from conftest import ESSVI_EQUITY, SSVI_EQUITY
 from volsurf import (
     DupireLocalVol,
     EssviSurface,
+    PerTenorFit,
     SmileModel,
     SsviSurface,
     SurfaceBuilder,
@@ -385,3 +386,68 @@ class TestDupireLocalVol:
         dupire = DupireLocalVol(surf)
         with pytest.raises((ValueError, RuntimeError)):
             dupire.local_vol(0.5, 0.0)
+
+
+class TestEssviTwoStageApi:
+    MARKET_3M = [
+        (80.0, 0.30), (90.0, 0.25), (95.0, 0.23),
+        (100.0, 0.21), (105.0, 0.23), (110.0, 0.25), (120.0, 0.30),
+    ]
+    MARKET_1Y = [
+        (80.0, 0.28), (90.0, 0.24), (95.0, 0.22),
+        (100.0, 0.20), (105.0, 0.22), (110.0, 0.24), (120.0, 0.28),
+    ]
+
+    def test_fit_per_tenor(self):
+        fits = EssviSurface.fit_per_tenor(
+            [self.MARKET_3M, self.MARKET_1Y],
+            [0.25, 1.0],
+            [100.0, 100.0],
+        )
+        assert len(fits) == 2
+        assert isinstance(fits[0], PerTenorFit)
+        assert fits[0].tenor == 0.25
+        assert fits[1].tenor == 1.0
+        assert fits[0].theta > 0
+        assert fits[1].theta > fits[0].theta
+        assert fits[0].rms_error < 0.01
+        assert len(fits[0].market_data) == 7
+
+    def test_from_per_tenor(self):
+        fits = EssviSurface.fit_per_tenor(
+            [self.MARKET_3M, self.MARKET_1Y],
+            [0.25, 1.0],
+            [100.0, 100.0],
+        )
+        surface = EssviSurface.from_per_tenor(fits)
+        v = surface.black_vol(0.5, 100.0)
+        assert v > 0 and math.isfinite(v)
+
+    def test_fit_prune_rebuild(self):
+        market_2y = [
+            (80.0, 0.26), (90.0, 0.22), (95.0, 0.21),
+            (100.0, 0.19), (105.0, 0.21), (110.0, 0.23), (120.0, 0.27),
+        ]
+        fits = EssviSurface.fit_per_tenor(
+            [self.MARKET_3M, self.MARKET_1Y, market_2y],
+            [0.25, 1.0, 2.0],
+            [100.0, 100.0, 100.0],
+        )
+        assert len(fits) == 3
+        # Drop middle tenor and rebuild
+        pruned = [fits[0], fits[2]]
+        surface = EssviSurface.from_per_tenor(pruned)
+        v = surface.black_vol(1.0, 100.0)
+        assert v > 0 and math.isfinite(v)
+
+    def test_per_tenor_fit_svi_getter(self):
+        fits = EssviSurface.fit_per_tenor(
+            [self.MARKET_3M, self.MARKET_1Y],
+            [0.25, 1.0],
+            [100.0, 100.0],
+        )
+        svi = fits[0].svi
+        assert svi.forward == 100.0
+        assert svi.expiry == 0.25
+        v = svi.vol(100.0)
+        assert v > 0 and math.isfinite(v)

--- a/python/tests/test_surface.py
+++ b/python/tests/test_surface.py
@@ -451,3 +451,15 @@ class TestEssviTwoStageApi:
         assert svi.expiry == 0.25
         v = svi.vol(100.0)
         assert v > 0 and math.isfinite(v)
+
+    def test_from_per_tenor_rejects_empty(self):
+        with pytest.raises((ValueError, RuntimeError)):
+            EssviSurface.from_per_tenor([])
+
+    def test_fit_per_tenor_rejects_length_mismatch(self):
+        with pytest.raises((ValueError, RuntimeError)):
+            EssviSurface.fit_per_tenor(
+                [self.MARKET_3M],
+                [0.25, 1.0],
+                [100.0],
+            )

--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -26,7 +26,7 @@ use crate::types::Vol;
 use crate::validate::validate_positive;
 
 /// SVI volatility smile with 5 parameters.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "SviSmileRaw", into = "SviSmileRaw")]
 pub struct SviSmile {
     forward: f64,

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -516,17 +516,11 @@ impl EssviSurface {
             let theta = svi.variance(forwards[i])?.0;
 
             let mut sum_sq = 0.0;
-            let mut n = 0usize;
             for &(strike, market_vol) in market_vols {
                 let fitted_vol = svi.vol(strike)?.0;
                 sum_sq += (fitted_vol - market_vol).powi(2);
-                n += 1;
             }
-            let rms_error = if n > 0 {
-                (sum_sq / n as f64).sqrt()
-            } else {
-                0.0
-            };
+            let rms_error = (sum_sq / market_vols.len() as f64).sqrt();
 
             fits.push(PerTenorFit {
                 tenor: tenors[i],
@@ -556,7 +550,8 @@ impl EssviSurface {
     ///
     /// # Errors
     /// Returns [`VolSurfError::InvalidInput`] if fewer than 2 tenors are
-    /// provided. Returns [`VolSurfError::CalibrationError`] if θ values are
+    /// provided or any fit has non-positive/non-finite tenor, forward, or θ.
+    /// Returns [`VolSurfError::CalibrationError`] if θ values are
     /// non-monotone or global optimization fails.
     pub fn from_per_tenor(fits: &[PerTenorFit]) -> error::Result<Self> {
         const MIN_TENORS: usize = 2;
@@ -574,6 +569,36 @@ impl EssviSurface {
                     fits.len()
                 ),
             });
+        }
+
+        #[cfg(feature = "logging")]
+        tracing::debug!(n_tenors = fits.len(), "eSSVI from_per_tenor started");
+
+        for (i, fit) in fits.iter().enumerate() {
+            if !fit.tenor.is_finite() || fit.tenor <= 0.0 {
+                return Err(VolSurfError::InvalidInput {
+                    message: format!(
+                        "fits[{i}].tenor must be positive and finite, got {}",
+                        fit.tenor
+                    ),
+                });
+            }
+            if !fit.forward.is_finite() || fit.forward <= 0.0 {
+                return Err(VolSurfError::InvalidInput {
+                    message: format!(
+                        "fits[{i}].forward must be positive and finite, got {}",
+                        fit.forward
+                    ),
+                });
+            }
+            if !fit.theta.is_finite() || fit.theta <= 0.0 {
+                return Err(VolSurfError::InvalidInput {
+                    message: format!(
+                        "fits[{i}].theta must be positive and finite, got {}",
+                        fit.theta
+                    ),
+                });
+            }
         }
 
         let tenors: Vec<f64> = fits.iter().map(|f| f.tenor).collect();
@@ -604,6 +629,7 @@ impl EssviSurface {
         let ln_xs: Vec<f64> = xs.iter().map(|&x| x.ln()).collect();
 
         // Stage 2: fit rho(theta) = rho_0 + (rho_m - rho_0) * (theta/theta_max)^a
+        // Quadratic spacing concentrates a-scan grid near a=0 where narrow optima live.
         let fit_a = |r0: f64, rm: f64| -> (f64, f64) {
             let d = rm - r0;
             if d.abs() < 1e-14 {
@@ -697,7 +723,8 @@ impl EssviSurface {
             }
         }
 
-        // Stage 3: optimize (eta, gamma) with fitted rho(theta)
+        // Stage 3: optimize (eta, gamma) with fitted rho(theta).
+        // Eq. 5.7 calendar no-arb enforced dynamically: a_eff = min(a_fitted, a_max(gamma)).
         let rho_diff = opt_rho_m - opt_rho_0;
         let objective = |eta: f64, gamma: f64| -> f64 {
             if eta <= 0.0 || !eta.is_finite() || !gamma.is_finite() || !(0.0..=1.0).contains(&gamma)
@@ -847,14 +874,6 @@ impl EssviSurface {
         tenors: &[f64],
         forwards: &[f64],
     ) -> error::Result<Self> {
-        if tenors.len() < 2 {
-            return Err(VolSurfError::InvalidInput {
-                message: format!(
-                    "at least 2 tenors required for eSSVI calibration, got {}",
-                    tenors.len()
-                ),
-            });
-        }
         let fits = Self::fit_per_tenor(market_data, tenors, forwards)?;
         Self::from_per_tenor(&fits)
     }
@@ -2806,6 +2825,44 @@ mod tests {
     fn fit_per_tenor_rejects_length_mismatch() {
         let err =
             EssviSurface::fit_per_tenor(&[vec![(100.0, 0.2)]], &[0.25, 0.5], &[100.0]).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::VolSurfError::InvalidInput { .. }
+        ));
+    }
+
+    #[test]
+    fn from_per_tenor_rejects_negative_tenor() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5];
+        let forwards = vec![100.0, 100.0];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+        let mut fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+        fits[0].tenor = -1.0;
+        let err = EssviSurface::from_per_tenor(&fits).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::VolSurfError::InvalidInput { .. }
+        ));
+    }
+
+    #[test]
+    fn from_per_tenor_rejects_nan_theta() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5];
+        let forwards = vec![100.0, 100.0];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+        let mut fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+        fits[1].theta = f64::NAN;
+        let err = EssviSurface::from_per_tenor(&fits).unwrap_err();
         assert!(matches!(
             err,
             crate::error::VolSurfError::InvalidInput { .. }

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -541,52 +541,24 @@ impl EssviSurface {
         Ok(fits)
     }
 
-    /// Calibrate an eSSVI surface from per-tenor market implied vols.
+    /// Build an eSSVI surface from pre-computed per-tenor SVI fits.
     ///
-    /// Uses a three-stage approach:
-    /// 1. Per-tenor SVI calibration to extract ATM total variances (θ) and skews (ρ)
-    /// 2. Fit the ρ(θ) parametric curve to per-tenor skews (Hendriks-Martini Eq. 5.6)
-    /// 3. Global optimization of (η, γ) via grid search + Nelder-Mead
+    /// This is Stage 2 of the two-stage calibration API. The caller runs
+    /// [`fit_per_tenor()`](Self::fit_per_tenor) first, inspects the results,
+    /// optionally prunes problematic tenors, then passes the remainder here.
     ///
-    /// The Eq. 5.7 calendar no-arbitrage constraint on the shape exponent `a` is
-    /// enforced dynamically as γ varies during Stage 3 optimization.
+    /// Internally fits the ρ(θ) parametric curve (Hendriks-Martini Eq. 5.6)
+    /// and optimizes (η, γ) via grid search + Nelder-Mead.
     ///
     /// # Arguments
-    /// * `market_data` — Per-tenor slices of (strike, implied_vol) pairs (≥ 5 per tenor)
-    /// * `tenors` — Expiry times in years, all positive and finite
-    /// * `forwards` — Forward prices at each tenor, all positive and finite
+    /// * `fits` — Per-tenor SVI calibration results (≥ 2, sorted by tenor,
+    ///   monotonically increasing θ)
     ///
     /// # Errors
-    /// Returns [`VolSurfError::InvalidInput`] for invalid inputs (< 2 tenors,
-    /// length mismatches, non-positive values). Returns [`VolSurfError::CalibrationError`]
-    /// if per-tenor SVI calibration or global optimization fails.
-    ///
-    /// # Example
-    /// ```
-    /// use volsurf::surface::EssviSurface;
-    ///
-    /// let data_3m: Vec<(f64, f64)> = (0..10)
-    ///     .map(|i| (80.0 + 4.0 * i as f64, 0.20 + 0.01 * (i as f64 - 5.0).abs()))
-    ///     .collect();
-    /// let data_1y: Vec<(f64, f64)> = (0..10)
-    ///     .map(|i| (80.0 + 4.0 * i as f64, 0.18 + 0.008 * (i as f64 - 5.0).abs()))
-    ///     .collect();
-    ///
-    /// let surface = EssviSurface::calibrate(
-    ///     &[data_3m, data_1y],
-    ///     &[0.25, 1.0],
-    ///     &[100.0, 100.0],
-    /// )?;
-    /// # Ok::<(), volsurf::VolSurfError>(())
-    /// ```
-    pub fn calibrate(
-        market_data: &[Vec<(f64, f64)>],
-        tenors: &[f64],
-        forwards: &[f64],
-    ) -> error::Result<Self> {
-        #[cfg(feature = "logging")]
-        tracing::debug!(n_tenors = tenors.len(), "eSSVI calibration started");
-
+    /// Returns [`VolSurfError::InvalidInput`] if fewer than 2 tenors are
+    /// provided. Returns [`VolSurfError::CalibrationError`] if θ values are
+    /// non-monotone or global optimization fails.
+    pub fn from_per_tenor(fits: &[PerTenorFit]) -> error::Result<Self> {
         const MIN_TENORS: usize = 2;
         const GRID_N: usize = 15;
         const NM_MAX_ITER: usize = 300;
@@ -595,58 +567,19 @@ impl EssviSurface {
         const A_SCAN_STEPS: usize = 20;
         const A_SCAN_MAX: f64 = 3.0;
 
-        if tenors.len() < MIN_TENORS {
+        if fits.len() < MIN_TENORS {
             return Err(VolSurfError::InvalidInput {
                 message: format!(
                     "at least {MIN_TENORS} tenors required for eSSVI calibration, got {}",
-                    tenors.len()
+                    fits.len()
                 ),
             });
         }
-        if tenors.len() != forwards.len() || tenors.len() != market_data.len() {
-            return Err(VolSurfError::InvalidInput {
-                message: format!(
-                    "tenors, forwards, and market_data must have the same length: {}, {}, {}",
-                    tenors.len(),
-                    forwards.len(),
-                    market_data.len()
-                ),
-            });
-        }
-        for (i, &t) in tenors.iter().enumerate() {
-            if !t.is_finite() || t <= 0.0 {
-                return Err(VolSurfError::InvalidInput {
-                    message: format!("tenors[{i}] must be positive and finite, got {t}"),
-                });
-            }
-        }
-        for (i, &f) in forwards.iter().enumerate() {
-            if !f.is_finite() || f <= 0.0 {
-                return Err(VolSurfError::InvalidInput {
-                    message: format!("forwards[{i}] must be positive and finite, got {f}"),
-                });
-            }
-        }
 
-        // Stage 1: per-tenor SVI calibration → thetas + per-tenor rho estimates
-        let n_tenors = tenors.len();
-        let mut thetas = Vec::with_capacity(n_tenors);
-        let mut rhos = Vec::with_capacity(n_tenors);
-
-        for (i, market_vols) in market_data.iter().enumerate() {
-            let svi = crate::smile::SviSmile::calibrate(forwards[i], tenors[i], market_vols)
-                .map_err(|e| VolSurfError::CalibrationError {
-                    message: format!(
-                        "per-tenor SVI calibration failed for tenor[{i}]={}: {e}",
-                        tenors[i]
-                    ),
-                    model: "eSSVI",
-                    rms_error: None,
-                })?;
-            let theta = svi.variance(forwards[i])?.0;
-            thetas.push(theta);
-            rhos.push(svi.rho());
-        }
+        let tenors: Vec<f64> = fits.iter().map(|f| f.tenor).collect();
+        let forwards: Vec<f64> = fits.iter().map(|f| f.forward).collect();
+        let thetas: Vec<f64> = fits.iter().map(|f| f.theta).collect();
+        let rhos: Vec<f64> = fits.iter().map(|f| f.svi.rho()).collect();
 
         for (i, w) in thetas.windows(2).enumerate() {
             if w[1] <= w[0] {
@@ -671,8 +604,6 @@ impl EssviSurface {
         let ln_xs: Vec<f64> = xs.iter().map(|&x| x.ln()).collect();
 
         // Stage 2: fit rho(theta) = rho_0 + (rho_m - rho_0) * (theta/theta_max)^a
-        // For given (rho_0, rho_m), scan `a` values to minimize RSS vs per-tenor rhos.
-        // Quadratic spacing concentrates grid near a=0 where narrow optima live (#22).
         let fit_a = |r0: f64, rm: f64| -> (f64, f64) {
             let d = rm - r0;
             if d.abs() < 1e-14 {
@@ -700,7 +631,6 @@ impl EssviSurface {
             (best_a, best_rss)
         };
 
-        // Adaptive grid range centered on observed rhos
         let rho_min = rhos.iter().cloned().fold(f64::INFINITY, f64::min);
         let rho_max = rhos.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
         let rho_lo = (rho_min - 0.15).max(-0.99);
@@ -723,7 +653,6 @@ impl EssviSurface {
             }
         }
 
-        // Refine (rho_0, rho_m) with Nelder-Mead
         let rho_step = (rho_hi - rho_lo) / (GRID_N as f64) * 0.5;
         let nm_config = crate::optim::NelderMeadConfig {
             max_iter: NM_MAX_ITER,
@@ -756,20 +685,19 @@ impl EssviSurface {
             "eSSVI Stage 2 rho(theta) fit complete"
         );
 
-        // Observation tuples: (theta, log_moneyness, total_variance, ln_theta_ratio)
+        // Observation tuples from original market data
         let mut all_points: Vec<(f64, f64, f64, f64)> =
-            Vec::with_capacity(market_data.iter().map(|v| v.len()).sum());
-        for (i, market_vols) in market_data.iter().enumerate() {
-            let ln_tr = (thetas[i].max(1e-10) / theta_max).clamp(0.0, 1.0).ln();
-            for &(strike, vol) in market_vols {
-                let k = (strike / forwards[i]).ln();
-                let w_obs = vol * vol * tenors[i];
-                all_points.push((thetas[i], k, w_obs, ln_tr));
+            Vec::with_capacity(fits.iter().map(|f| f.market_data.len()).sum());
+        for fit in fits {
+            let ln_tr = (fit.theta.max(1e-10) / theta_max).clamp(0.0, 1.0).ln();
+            for &(strike, vol) in &fit.market_data {
+                let k = (strike / fit.forward).ln();
+                let w_obs = vol * vol * fit.tenor;
+                all_points.push((fit.theta, k, w_obs, ln_tr));
             }
         }
 
-        // Stage 3: optimize (eta, gamma) with fitted rho(theta).
-        // Eq. 5.7 enforced dynamically: a_eff = min(a_fitted, a_max(gamma)).
+        // Stage 3: optimize (eta, gamma) with fitted rho(theta)
         let rho_diff = opt_rho_m - opt_rho_0;
         let objective = |eta: f64, gamma: f64| -> f64 {
             if eta <= 0.0 || !eta.is_finite() || !gamma.is_finite() || !(0.0..=1.0).contains(&gamma)
@@ -870,20 +798,65 @@ impl EssviSurface {
         );
 
         Self::new(
-            opt_rho_0,
-            opt_rho_m,
-            final_a,
-            opt_eta,
-            opt_gamma,
-            tenors.to_vec(),
-            forwards.to_vec(),
-            thetas,
+            opt_rho_0, opt_rho_m, final_a, opt_eta, opt_gamma, tenors, forwards, thetas,
         )
         .map_err(|e| VolSurfError::CalibrationError {
             message: format!("calibrated eSSVI params invalid: {e}"),
             model: "eSSVI",
             rms_error: Some(rms),
         })
+    }
+
+    /// Calibrate an eSSVI surface from per-tenor market implied vols.
+    ///
+    /// Convenience wrapper that calls [`fit_per_tenor()`](Self::fit_per_tenor)
+    /// followed by [`from_per_tenor()`](Self::from_per_tenor). Use the
+    /// two-stage API directly when you need to inspect or prune per-tenor
+    /// results before the global fit.
+    ///
+    /// # Arguments
+    /// * `market_data` — Per-tenor slices of (strike, implied_vol) pairs (≥ 5 per tenor)
+    /// * `tenors` — Expiry times in years, all positive and finite
+    /// * `forwards` — Forward prices at each tenor, all positive and finite
+    ///
+    /// # Errors
+    /// Returns [`VolSurfError::InvalidInput`] for invalid inputs (< 2 tenors,
+    /// length mismatches, non-positive values). Returns [`VolSurfError::CalibrationError`]
+    /// if per-tenor SVI calibration or global optimization fails.
+    ///
+    /// # Example
+    /// ```
+    /// use volsurf::surface::EssviSurface;
+    ///
+    /// let data_3m: Vec<(f64, f64)> = (0..10)
+    ///     .map(|i| (80.0 + 4.0 * i as f64, 0.20 + 0.01 * (i as f64 - 5.0).abs()))
+    ///     .collect();
+    /// let data_1y: Vec<(f64, f64)> = (0..10)
+    ///     .map(|i| (80.0 + 4.0 * i as f64, 0.18 + 0.008 * (i as f64 - 5.0).abs()))
+    ///     .collect();
+    ///
+    /// let surface = EssviSurface::calibrate(
+    ///     &[data_3m, data_1y],
+    ///     &[0.25, 1.0],
+    ///     &[100.0, 100.0],
+    /// )?;
+    /// # Ok::<(), volsurf::VolSurfError>(())
+    /// ```
+    pub fn calibrate(
+        market_data: &[Vec<(f64, f64)>],
+        tenors: &[f64],
+        forwards: &[f64],
+    ) -> error::Result<Self> {
+        if tenors.len() < 2 {
+            return Err(VolSurfError::InvalidInput {
+                message: format!(
+                    "at least 2 tenors required for eSSVI calibration, got {}",
+                    tenors.len()
+                ),
+            });
+        }
+        let fits = Self::fit_per_tenor(market_data, tenors, forwards)?;
+        Self::from_per_tenor(&fits)
     }
 
     /// Maturity-dependent correlation ρ(θ) (Hendriks-Martini 2019, Eq. 3.1).

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -38,6 +38,27 @@ pub struct StructuralViolation {
     pub condition_rhs: f64,
 }
 
+/// Result of per-tenor SVI calibration, used as input to
+/// [`EssviSurface::from_per_tenor()`].
+///
+/// Carries the calibrated [`SviSmile`], ATM total variance θ, fit RMS error,
+/// and the original market data needed by the global eSSVI optimizer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerTenorFit {
+    /// Time to expiry in years.
+    pub tenor: f64,
+    /// Forward price at this tenor.
+    pub forward: f64,
+    /// Calibrated SVI smile.
+    pub svi: crate::smile::SviSmile,
+    /// ATM total variance θ = σ²(F)·T.
+    pub theta: f64,
+    /// RMS implied-vol fitting error (vol space, not total variance).
+    pub rms_error: f64,
+    /// Original (strike, implied_vol) market observations.
+    pub market_data: Vec<(f64, f64)>,
+}
+
 /// A single-tenor slice through an eSSVI surface.
 ///
 /// Evaluates the eSSVI total variance formula at a fixed ATM total variance θ,
@@ -429,6 +450,95 @@ impl EssviSurface {
             thetas,
             theta_max,
         })
+    }
+
+    /// Run per-tenor SVI calibration without the global eSSVI fit.
+    ///
+    /// Returns one [`PerTenorFit`] per tenor, each carrying the calibrated
+    /// [`SviSmile`](crate::smile::SviSmile), ATM total variance θ, fitting
+    /// RMS error, and the original market data. The caller can inspect the
+    /// results, prune problematic tenors, and pass the remainder to
+    /// [`from_per_tenor()`](Self::from_per_tenor).
+    ///
+    /// No monotonicity check is performed — that is the caller's responsibility
+    /// (or handled automatically by `from_per_tenor()`).
+    ///
+    /// # Arguments
+    /// * `market_data` — Per-tenor slices of (strike, implied_vol) pairs (≥ 5 per tenor)
+    /// * `tenors` — Expiry times in years, all positive and finite
+    /// * `forwards` — Forward prices at each tenor, all positive and finite
+    ///
+    /// # Errors
+    /// Returns [`VolSurfError::InvalidInput`] for length mismatches or
+    /// non-positive values. Returns [`VolSurfError::CalibrationError`] if
+    /// any per-tenor SVI calibration fails.
+    pub fn fit_per_tenor(
+        market_data: &[Vec<(f64, f64)>],
+        tenors: &[f64],
+        forwards: &[f64],
+    ) -> error::Result<Vec<PerTenorFit>> {
+        if tenors.len() != forwards.len() || tenors.len() != market_data.len() {
+            return Err(VolSurfError::InvalidInput {
+                message: format!(
+                    "tenors, forwards, and market_data must have the same length: {}, {}, {}",
+                    tenors.len(),
+                    forwards.len(),
+                    market_data.len()
+                ),
+            });
+        }
+        for (i, &t) in tenors.iter().enumerate() {
+            if !t.is_finite() || t <= 0.0 {
+                return Err(VolSurfError::InvalidInput {
+                    message: format!("tenors[{i}] must be positive and finite, got {t}"),
+                });
+            }
+        }
+        for (i, &f) in forwards.iter().enumerate() {
+            if !f.is_finite() || f <= 0.0 {
+                return Err(VolSurfError::InvalidInput {
+                    message: format!("forwards[{i}] must be positive and finite, got {f}"),
+                });
+            }
+        }
+
+        let mut fits = Vec::with_capacity(tenors.len());
+        for (i, market_vols) in market_data.iter().enumerate() {
+            let svi = crate::smile::SviSmile::calibrate(forwards[i], tenors[i], market_vols)
+                .map_err(|e| VolSurfError::CalibrationError {
+                    message: format!(
+                        "per-tenor SVI calibration failed for tenor[{i}]={}: {e}",
+                        tenors[i]
+                    ),
+                    model: "eSSVI",
+                    rms_error: None,
+                })?;
+            let theta = svi.variance(forwards[i])?.0;
+
+            let mut sum_sq = 0.0;
+            let mut n = 0usize;
+            for &(strike, market_vol) in market_vols {
+                let fitted_vol = svi.vol(strike)?.0;
+                sum_sq += (fitted_vol - market_vol).powi(2);
+                n += 1;
+            }
+            let rms_error = if n > 0 {
+                (sum_sq / n as f64).sqrt()
+            } else {
+                0.0
+            };
+
+            fits.push(PerTenorFit {
+                tenor: tenors[i],
+                forward: forwards[i],
+                svi,
+                theta,
+                rms_error,
+                market_data: market_vols.clone(),
+            });
+        }
+
+        Ok(fits)
     }
 
     /// Calibrate an eSSVI surface from per-tenor market implied vols.

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -2641,4 +2641,174 @@ mod tests {
             "expected non-monotone error, got: {err}"
         );
     }
+
+    // Two-stage API tests
+
+    #[test]
+    fn fit_per_tenor_returns_correct_fits() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5, 1.0, 2.0];
+        let forwards = vec![100.0; 4];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+
+        let fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+        assert_eq!(fits.len(), 4);
+
+        for (i, fit) in fits.iter().enumerate() {
+            assert_eq!(fit.tenor, tenors[i]);
+            assert_eq!(fit.forward, forwards[i]);
+            assert!(fit.theta > 0.0, "theta should be positive");
+            assert!(
+                fit.rms_error < 0.005,
+                "per-tenor RMS {:.4} too high",
+                fit.rms_error
+            );
+            assert!(fit.svi.rho().abs() < 1.0, "rho out of range");
+            assert_eq!(fit.market_data.len(), 15);
+        }
+
+        for w in fits.windows(2) {
+            assert!(w[1].theta > w[0].theta, "thetas should be monotone");
+        }
+    }
+
+    #[test]
+    fn from_per_tenor_with_pruned_tenors() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5, 1.0, 2.0];
+        let forwards = vec![100.0; 4];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+
+        let fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+
+        // Drop tenor[1] (0.5y) — middle tenor, keeps monotone thetas
+        let pruned: Vec<_> = fits
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != 1)
+            .map(|(_, f)| f.clone())
+            .collect();
+        assert_eq!(pruned.len(), 3);
+
+        let surface = EssviSurface::from_per_tenor(&pruned).unwrap();
+        let vol = surface.black_vol(1.0, 100.0).unwrap();
+        assert!(vol.0 > 0.0 && vol.0 < 1.0, "vol {:.4} out of range", vol.0);
+    }
+
+    #[test]
+    fn calibrate_equivalence_with_two_stage() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5, 1.0, 2.0];
+        let forwards = vec![100.0; 4];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+
+        let one_shot = EssviSurface::calibrate(&market_data, &tenors, &forwards).unwrap();
+        let fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+        let two_stage = EssviSurface::from_per_tenor(&fits).unwrap();
+
+        // Should be bit-identical since calibrate() delegates
+        assert_eq!(one_shot.rho_0(), two_stage.rho_0());
+        assert_eq!(one_shot.rho_m(), two_stage.rho_m());
+        assert_eq!(one_shot.a(), two_stage.a());
+        assert_eq!(one_shot.eta(), two_stage.eta());
+        assert_eq!(one_shot.gamma(), two_stage.gamma());
+
+        for &t in &[0.25, 0.5, 1.0, 2.0] {
+            for &k in &[80.0, 100.0, 120.0] {
+                let v1 = one_shot.black_vol(t, k).unwrap();
+                let v2 = two_stage.black_vol(t, k).unwrap();
+                assert_eq!(v1.0, v2.0, "vol mismatch at t={t}, k={k}");
+            }
+        }
+    }
+
+    #[test]
+    fn per_tenor_fit_serde_round_trip() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5, 1.0, 2.0];
+        let forwards = vec![100.0; 4];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+        let fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+
+        let json = serde_json::to_string(&fits[0]).unwrap();
+        let deser: PerTenorFit = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.tenor, fits[0].tenor);
+        assert_eq!(deser.forward, fits[0].forward);
+        assert_eq!(deser.theta, fits[0].theta);
+        assert_eq!(deser.rms_error, fits[0].rms_error);
+        assert_eq!(deser.svi, fits[0].svi);
+        assert_eq!(deser.market_data.len(), fits[0].market_data.len());
+    }
+
+    #[test]
+    fn from_per_tenor_rejects_empty() {
+        let err = EssviSurface::from_per_tenor(&[]).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::VolSurfError::InvalidInput { .. }
+        ));
+    }
+
+    #[test]
+    fn from_per_tenor_rejects_single_tenor() {
+        let original = equity_surface();
+        let tenors = vec![0.25];
+        let forwards = vec![100.0];
+        let strikes: Vec<Vec<f64>> = vec![(0..15).map(|i| 70.0 + 4.0 * i as f64).collect()];
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+        let fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+        let err = EssviSurface::from_per_tenor(&fits).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::VolSurfError::InvalidInput { .. }
+        ));
+    }
+
+    #[test]
+    fn from_per_tenor_rejects_non_monotone_theta() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5];
+        let forwards = vec![100.0, 100.0];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+        let mut fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+
+        // Swap thetas to break monotonicity
+        fits[0].theta = fits[1].theta + 0.01;
+
+        let err = EssviSurface::from_per_tenor(&fits).unwrap_err();
+        assert!(
+            err.to_string().contains("non-monotone"),
+            "expected non-monotone error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fit_per_tenor_rejects_length_mismatch() {
+        let err =
+            EssviSurface::fit_per_tenor(&[vec![(100.0, 0.2)]], &[0.25, 0.5], &[100.0]).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::VolSurfError::InvalidInput { .. }
+        ));
+    }
 }

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -41,8 +41,10 @@ pub struct StructuralViolation {
 /// Result of per-tenor SVI calibration, used as input to
 /// [`EssviSurface::from_per_tenor()`].
 ///
-/// Carries the calibrated [`SviSmile`], ATM total variance θ, fit RMS error,
+/// Carries the calibrated [`SviSmile`](crate::smile::SviSmile), ATM total variance θ, fit RMS error,
 /// and the original market data needed by the global eSSVI optimizer.
+/// `from_per_tenor()` validates `tenor`, `forward`, and `theta` but not
+/// individual `market_data` entries.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PerTenorFit {
     /// Time to expiry in years.
@@ -2862,6 +2864,25 @@ mod tests {
         let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
         let mut fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
         fits[1].theta = f64::NAN;
+        let err = EssviSurface::from_per_tenor(&fits).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::VolSurfError::InvalidInput { .. }
+        ));
+    }
+
+    #[test]
+    fn from_per_tenor_rejects_zero_theta() {
+        let original = equity_surface();
+        let tenors = vec![0.25, 0.5];
+        let forwards = vec![100.0, 100.0];
+        let strikes: Vec<Vec<f64>> = tenors
+            .iter()
+            .map(|_| (0..15).map(|i| 70.0 + 4.0 * i as f64).collect())
+            .collect();
+        let market_data = synthetic_essvi_data(&original, &tenors, &strikes);
+        let mut fits = EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).unwrap();
+        fits[0].theta = 0.0;
         let err = EssviSurface::from_per_tenor(&fits).unwrap_err();
         assert!(matches!(
             err,

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -18,7 +18,7 @@ pub mod ssvi;
 
 pub use arbitrage::{CalendarViolation, SurfaceDiagnostics};
 pub use builder::{SmileModel, SurfaceBuilder};
-pub use essvi::{EssviSlice, EssviSurface, StructuralViolation};
+pub use essvi::{EssviSlice, EssviSurface, PerTenorFit, StructuralViolation};
 pub use piecewise::PiecewiseSurface;
 pub use ssvi::{SsviSlice, SsviSurface};
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -11,7 +11,7 @@ pub use arbitrage::{
 };
 pub use builder::{WasmPiecewiseSurface, WasmSurfaceBuilder};
 pub use smile::{WasmSabrSmile, WasmSmile, WasmSviSmile};
-pub use surface::{WasmEssviSurface, WasmSsviSurface};
+pub use surface::{WasmEssviSurface, WasmPerTenorFit, WasmSsviSurface};
 
 #[wasm_bindgen]
 pub fn version() -> String {

--- a/wasm/src/smile.rs
+++ b/wasm/src/smile.rs
@@ -18,6 +18,12 @@ pub struct WasmSviSmile {
     inner: SviSmile,
 }
 
+impl WasmSviSmile {
+    pub(crate) fn from_inner(inner: SviSmile) -> Self {
+        Self { inner }
+    }
+}
+
 #[wasm_bindgen]
 impl WasmSviSmile {
     #[wasm_bindgen(constructor)]

--- a/wasm/src/surface.rs
+++ b/wasm/src/surface.rs
@@ -1,10 +1,10 @@
 use volsurf::VolSurface;
-use volsurf::surface::{EssviSurface, SsviSurface};
+use volsurf::surface::{EssviSurface, PerTenorFit, SsviSurface};
 use wasm_bindgen::prelude::*;
 
 use crate::arbitrage::WasmSurfaceDiagnostics;
 use crate::error::to_js_err;
-use crate::smile::WasmSmile;
+use crate::smile::{WasmSmile, WasmSviSmile};
 
 fn market_data_from_flat(
     flat: &[f64],
@@ -235,5 +235,67 @@ impl WasmEssviSurface {
         let market_data = market_data_from_flat(&market_data_flat, &tenor_sizes)?;
         let inner = EssviSurface::calibrate(&market_data, &tenors, &forwards).map_err(to_js_err)?;
         Ok(Self { inner })
+    }
+
+    pub fn fit_per_tenor(
+        market_data_flat: Vec<f64>,
+        tenor_sizes: Vec<usize>,
+        tenors: Vec<f64>,
+        forwards: Vec<f64>,
+    ) -> Result<Vec<WasmPerTenorFit>, JsValue> {
+        let market_data = market_data_from_flat(&market_data_flat, &tenor_sizes)?;
+        let fits =
+            EssviSurface::fit_per_tenor(&market_data, &tenors, &forwards).map_err(to_js_err)?;
+        Ok(fits.into_iter().map(WasmPerTenorFit::from).collect())
+    }
+
+    pub fn from_per_tenor_json(json: &str) -> Result<WasmEssviSurface, JsValue> {
+        let fits: Vec<PerTenorFit> =
+            serde_json::from_str(json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let inner = EssviSurface::from_per_tenor(&fits).map_err(to_js_err)?;
+        Ok(Self { inner })
+    }
+}
+
+#[wasm_bindgen]
+pub struct WasmPerTenorFit {
+    inner: PerTenorFit,
+}
+
+impl From<PerTenorFit> for WasmPerTenorFit {
+    fn from(inner: PerTenorFit) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl WasmPerTenorFit {
+    #[wasm_bindgen(getter)]
+    pub fn tenor(&self) -> f64 {
+        self.inner.tenor
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn forward(&self) -> f64 {
+        self.inner.forward
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn theta(&self) -> f64 {
+        self.inner.theta
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn rms_error(&self) -> f64 {
+        self.inner.rms_error
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn svi(&self) -> WasmSviSmile {
+        WasmSviSmile::from_inner(self.inner.svi.clone())
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string(&self.inner).map_err(|e| JsValue::from_str(&e.to_string()))
     }
 }

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -577,3 +577,39 @@ fn essvi_calibrate_mismatched_sizes() {
     let (flat, _, tenors, fwds) = two_tenor_market_data();
     assert!(WasmEssviSurface::calibrate(flat, vec![7, 5], tenors, fwds).is_err());
 }
+
+// ── Two-stage eSSVI API ──
+
+#[wasm_bindgen_test]
+fn essvi_fit_per_tenor() {
+    let (flat, sizes, tenors, fwds) = two_tenor_market_data();
+    let fits = WasmEssviSurface::fit_per_tenor(flat, sizes, tenors, fwds).unwrap();
+    assert_eq!(fits.len(), 2);
+    assert!((fits[0].tenor() - 0.25).abs() < 1e-12);
+    assert!((fits[1].tenor() - 1.0).abs() < 1e-12);
+    assert!(fits[0].theta() > 0.0);
+    assert!(fits[1].theta() > fits[0].theta());
+    assert!(fits[0].rms_error() < 0.01);
+}
+
+#[wasm_bindgen_test]
+fn essvi_fit_per_tenor_svi_getter() {
+    let (flat, sizes, tenors, fwds) = two_tenor_market_data();
+    let fits = WasmEssviSurface::fit_per_tenor(flat, sizes, tenors, fwds).unwrap();
+    let svi = fits[0].svi();
+    assert!((svi.forward() - 100.0).abs() < 1e-12);
+    let vol = svi.vol(100.0).unwrap();
+    assert!(vol > 0.0 && vol < 1.0);
+}
+
+#[wasm_bindgen_test]
+fn essvi_from_per_tenor_json() {
+    let (flat, sizes, tenors, fwds) = two_tenor_market_data();
+    let fits = WasmEssviSurface::fit_per_tenor(flat, sizes, tenors, fwds).unwrap();
+    let json0 = fits[0].to_json().unwrap();
+    let json1 = fits[1].to_json().unwrap();
+    let json = format!("[{json0},{json1}]");
+    let surf = WasmEssviSurface::from_per_tenor_json(&json).unwrap();
+    let vol = surf.black_vol(0.5, 100.0).unwrap();
+    assert!(vol > 0.0 && vol < 1.0, "interpolated vol={vol}");
+}

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -613,3 +613,13 @@ fn essvi_from_per_tenor_json() {
     let vol = surf.black_vol(0.5, 100.0).unwrap();
     assert!(vol > 0.0 && vol < 1.0, "interpolated vol={vol}");
 }
+
+#[wasm_bindgen_test]
+fn essvi_from_per_tenor_json_rejects_empty() {
+    assert!(WasmEssviSurface::from_per_tenor_json("[]").is_err());
+}
+
+#[wasm_bindgen_test]
+fn essvi_from_per_tenor_json_rejects_invalid() {
+    assert!(WasmEssviSurface::from_per_tenor_json("not json").is_err());
+}

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -578,8 +578,6 @@ fn essvi_calibrate_mismatched_sizes() {
     assert!(WasmEssviSurface::calibrate(flat, vec![7, 5], tenors, fwds).is_err());
 }
 
-// ── Two-stage eSSVI API ──
-
 #[wasm_bindgen_test]
 fn essvi_fit_per_tenor() {
     let (flat, sizes, tenors, fwds) = two_tenor_market_data();


### PR DESCRIPTION
## Summary

Splits `EssviSurface::calibrate()` into a two-stage API so callers can inspect, prune, or modify per-tenor SVI fits before the global eSSVI optimization.

- **`fit_per_tenor()`** — Stage 1: per-tenor SVI calibration → `Vec<PerTenorFit>`
- **`from_per_tenor()`** — Stage 2: ρ(θ) fitting + (η, γ) optimization → `EssviSurface`
- **`calibrate()`** — unchanged API, now a thin wrapper over the two-stage path (bit-identical results)

### New types
- `PerTenorFit` — carries calibrated `SviSmile`, ATM θ, RMS error, and original market data

### Bindings
- **Python**: `PyPerTenorFit` (frozen, property getters), `fit_per_tenor()`, `from_per_tenor()`
- **WASM**: `WasmPerTenorFit` (getter attributes, `to_json()`), `fit_per_tenor()`, `from_per_tenor_json()`

### Validation
- `from_per_tenor()` validates tenor/forward/theta positive+finite, monotone θ, ≥2 tenors

Closes #88

## Test plan

- [x] 901 Rust tests (13 new: correctness, equivalence, serde round-trip, 6 error paths)
- [x] 223 Python tests (6 new: fit, rebuild, prune, svi getter, 2 error paths)
- [x] 46 WASM tests (5 new: fit, svi getter, JSON round-trip, 2 error paths)
- [x] Clippy clean (all features)
- [x] `calibrate()` bit-identical to two-stage path (tested with `assert_eq!` on f64)

Recommend squash merge.