### PR TITLE
fix: reject negative and zero strikes in SplineSmile::new()

### DIFF
--- a/src/smile/spline.rs
+++ b/src/smile/spline.rs
@@ -125,11 +125,7 @@ impl SplineSmile {
             });
         }
         for k in &strikes {
-            if !k.is_finite() {
-                return Err(VolSurfError::InvalidInput {
-                    message: format!("strikes must be finite, got {k}"),
-                });
-            }
+            validate_positive(*k, "strike")?;
         }
         for (i, w) in strikes.windows(2).enumerate() {
             if w[1] <= w[0] {
@@ -390,6 +386,18 @@ mod tests {
     #[test]
     fn rejects_negative_forward() {
         let result = SplineSmile::new(-100.0, 0.25, vec![1.0, 2.0, 3.0], vec![0.04, 0.04, 0.04]);
+        assert!(matches!(result, Err(VolSurfError::InvalidInput { .. })));
+    }
+
+    #[test]
+    fn rejects_negative_strike() {
+        let result = SplineSmile::new(100.0, 0.25, vec![-1.0, 2.0, 3.0], vec![0.04, 0.04, 0.04]);
+        assert!(matches!(result, Err(VolSurfError::InvalidInput { .. })));
+    }
+
+    #[test]
+    fn rejects_zero_strike() {
+        let result = SplineSmile::new(100.0, 0.25, vec![0.0, 2.0, 3.0], vec![0.04, 0.04, 0.04]);
         assert!(matches!(result, Err(VolSurfError::InvalidInput { .. })));
     }
 


### PR DESCRIPTION
## Summary
- Replace `is_finite()` check with `validate_positive()` in `SplineSmile::new()` so negative and zero strikes are caught at construction time, not deferred to `vol()`/`variance()` query time
- Add tests for negative and zero strike rejection

## Test plan
- [x] `rejects_negative_strike` — `SplineSmile::new()` with negative strike returns `Err`
- [x] `rejects_zero_strike` — `SplineSmile::new()` with zero strike returns `Err`
- [x] Full test suite passes (903 tests)
- [x] Clippy clean, rustfmt clean

Closes #56