### PR TITLE
fix: tighten Roger Lee test assertion and add calibration regression guard

### DIFF
--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -1780,7 +1780,7 @@ mod tests {
 
     #[test]
     fn roger_lee_bound_prevents_calibration_to_steep_wings() {
-        // Data with extremely steep wings that would require b*(1+|rho|) > 4 to fit.
+        // Data with extremely steep wings that would require b*(1+|rho|) > 2 to fit.
         let forward = 100.0;
         let expiry = 1.0;
         let data: Vec<(f64, f64)> = vec![
@@ -1797,10 +1797,9 @@ mod tests {
 
         match SviSmile::calibrate(forward, expiry, &data) {
             Ok(smile) => {
-                // If accepted, Lee bound must hold
                 let lee = smile.b * (1.0 + smile.rho.abs());
                 assert!(
-                    lee <= 4.0,
+                    lee <= 2.0,
                     "Roger Lee violated in calibrated params: b*(1+|rho|) = {lee}"
                 );
             }

--- a/tests/svi_robustness.rs
+++ b/tests/svi_robustness.rs
@@ -255,5 +255,27 @@ fn mar10_apr17_38dte_full_range() {
     );
 }
 
+// Regression guard: the stable fixture at ±5% must always calibrate successfully.
+// This catches regressions where valid, well-behaved data starts failing.
+#[test]
+fn stable_fixture_must_succeed() {
+    let f = load_fixture("jan24_feb21_28dte_stable.json");
+    for pct in [0.05, 0.10, 0.15] {
+        let subset = filter_by_moneyness(&f.market_vols, f.forward, pct);
+        if subset.len() < 5 {
+            continue;
+        }
+        let smile = SviSmile::calibrate(f.forward, f.expiry_years, &subset)
+            .unwrap_or_else(|e| panic!("stable ±{:.0}% must succeed: {e}", pct * 100.0));
+        let atm = SmileSection::vol(&smile, f.forward).unwrap().0;
+        let ratio = atm / f.expected_atm_iv;
+        assert!(
+            ratio > 0.8 && ratio < 1.2,
+            "stable ±{:.0}%: ATM ratio {ratio:.3} outside [0.8, 1.2]",
+            pct * 100.0
+        );
+    }
+}
+
 // Roger Lee bound tests live in src/smile/svi.rs (new_rejects_roger_lee_bound,
 // new_accepts_roger_lee_boundary) — not duplicated here.


### PR DESCRIPTION
## Summary
- Tighten `roger_lee_bound_prevents_calibration_to_steep_wings` test assertion from `<= 4.0` to `<= 2.0`, matching the actual Roger Lee bound enforced in both constructor and objective closure
- Add `stable_fixture_must_succeed` regression guard test that asserts well-behaved fixture data must always calibrate successfully

Addresses roborev review #375.

## Test plan
- [x] All 930 tests pass
- [x] Zero clippy warnings
- [x] Roger Lee bound tests pass with tightened assertion
- [x] New regression guard test passes for stable fixture at ±5/10/15%