### PR TITLE
fix: preserve WASM/Python builder state on failed build (#60)

### DIFF
--- a/python/src/surface.rs
+++ b/python/src/surface.rs
@@ -377,9 +377,15 @@ impl PySurfaceBuilder {
 
     fn build(&mut self) -> PyResult<PySurface> {
         let b = self.inner.take().ok_or_else(consumed)?;
-        let surface = b.build().map_err(to_py_err)?;
-        Ok(PySurface {
-            inner: Arc::new(surface) as Arc<dyn VolSurface>,
-        })
+        let backup = b.clone();
+        match b.build() {
+            Ok(surface) => Ok(PySurface {
+                inner: Arc::new(surface) as Arc<dyn VolSurface>,
+            }),
+            Err(e) => {
+                self.inner = Some(backup);
+                Err(to_py_err(e))
+            }
+        }
     }
 }

--- a/python/tests/test_surface.py
+++ b/python/tests/test_surface.py
@@ -196,6 +196,28 @@ class TestSurfaceBuilder:
         with pytest.raises(RuntimeError, match="already consumed"):
             b.add_tenor_with_forward(0.5, STRIKES, VOLS, 101.0)
 
+    def test_build_recoverable_after_failure(self):
+        b = SurfaceBuilder()
+        b.rate(0.05)
+        b.add_tenor(0.25, STRIKES, VOLS)
+        with pytest.raises(ValueError, match="spot"):
+            b.build()
+        b.spot(100.0)
+        surface = b.build()
+        vol = surface.black_vol(0.25, 100.0)
+        assert 0.0 < vol < 1.0
+
+    def test_build_consumed_after_successful_retry(self):
+        b = SurfaceBuilder()
+        b.rate(0.05)
+        b.add_tenor(0.25, STRIKES, VOLS)
+        with pytest.raises(ValueError, match="spot"):
+            b.build()
+        b.spot(100.0)
+        b.build()
+        with pytest.raises(RuntimeError, match="already consumed"):
+            b.build()
+
 
 class TestSsviSurface:
     def test_construct(self):

--- a/src/surface/builder.rs
+++ b/src/surface/builder.rs
@@ -113,7 +113,7 @@ impl TryFrom<SmileModelRaw> for SmileModel {
 /// assert!(vol.0 > 0.0);
 /// # Ok::<(), volsurf::VolSurfError>(())
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SurfaceBuilder {
     spot: Option<f64>,
     rate: Option<f64>,
@@ -122,7 +122,7 @@ pub struct SurfaceBuilder {
     tenor_data: Vec<TenorData>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct TenorData {
     expiry: f64,
     strikes: Vec<f64>,

--- a/wasm/src/builder.rs
+++ b/wasm/src/builder.rs
@@ -93,10 +93,16 @@ impl WasmSurfaceBuilder {
 
     pub fn build(&mut self) -> Result<WasmPiecewiseSurface, JsValue> {
         let b = self.inner.take().ok_or_else(consumed)?;
-        let surface = b.build().map_err(to_js_err)?;
-        Ok(WasmPiecewiseSurface {
-            inner: Arc::new(surface) as Arc<dyn VolSurface>,
-        })
+        let backup = b.clone();
+        match b.build() {
+            Ok(surface) => Ok(WasmPiecewiseSurface {
+                inner: Arc::new(surface) as Arc<dyn VolSurface>,
+            }),
+            Err(e) => {
+                self.inner = Some(backup);
+                Err(to_js_err(e))
+            }
+        }
     }
 }
 

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -320,6 +320,34 @@ fn builder_consumed_after_build() {
     assert!(builder.build().is_err());
 }
 
+#[wasm_bindgen_test]
+fn builder_recoverable_after_failed_build() {
+    let (strikes, vols) = nine_strike_smile();
+    let mut builder = WasmSurfaceBuilder::new();
+    builder.rate(0.05).unwrap();
+    builder.add_tenor(1.0, strikes, vols).unwrap();
+
+    assert!(builder.build().is_err(), "build without spot should fail");
+
+    builder.spot(100.0).unwrap();
+    let surface = builder.build().unwrap();
+    let vol = surface.black_vol(1.0, 100.0).unwrap();
+    assert!(vol > 0.0 && vol < 1.0, "vol={vol}");
+}
+
+#[wasm_bindgen_test]
+fn builder_consumed_after_successful_retry() {
+    let (strikes, vols) = nine_strike_smile();
+    let mut builder = WasmSurfaceBuilder::new();
+    builder.rate(0.05).unwrap();
+    builder.add_tenor(1.0, strikes, vols).unwrap();
+    assert!(builder.build().is_err());
+
+    builder.spot(100.0).unwrap();
+    builder.build().unwrap();
+    assert!(builder.build().is_err(), "should be consumed after success");
+}
+
 // ── Edge cases ──
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary

- Add `Clone` derive to `SurfaceBuilder` and `TenorData` (non-breaking, semver-compatible)
- Use take-clone-restore pattern in both WASM and Python `build()` methods: clone as backup before build, restore on failure, drop on success
- Builder is preserved after failed `build()`, allowing users to fix issues and retry
- Success path behavior unchanged — builder is still consumed after successful build

Closes #60

## Changes

| File | Change |
|------|--------|
| `src/surface/builder.rs` | `#[derive(Debug, Clone)]` on `SurfaceBuilder` and `TenorData` |
| `wasm/src/builder.rs` | Take-clone-restore in `build()` |
| `python/src/surface.rs` | Take-clone-restore in `build()` |
| `wasm/tests/smoke.rs` | 2 new tests: recovery after failure, consumed after successful retry |
| `python/tests/test_surface.py` | 2 new tests: same scenarios |

## Test plan

- [x] 930 Rust tests pass (819 lib + 111 integration/property/doc)
- [x] 48 WASM tests pass (46 existing + 2 new)
- [x] 225 Python tests pass (223 existing + 2 new)
- [x] Zero clippy warnings
- [x] Roborev review #393 addressed (clone moved to backup path, Python test narrowed to ValueError)