### PR TITLE
fix: add debug_assert guards and tests to interpolate_theta_forward (#53)

### DIFF
--- a/src/surface/interp.rs
+++ b/src/surface/interp.rs
@@ -125,12 +125,14 @@ mod tests {
         assert_abs_diff_eq!(fwd, 102.0, epsilon = 1e-14);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "tenors must not be empty")]
     fn panics_on_empty_input() {
         interpolate_theta_forward(&[], &[], &[], 0.5);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
     fn panics_on_mismatched_lengths() {


### PR DESCRIPTION
## Summary

- Add `debug_assert!` guards to `interpolate_theta_forward` for non-empty slices and equal lengths
- Add 11 direct unit tests covering all 4 code paths (exact match, left/right extrapolation, interpolation)
- Gate `#[should_panic]` tests with `#[cfg(debug_assertions)]` for release-mode safety

## Context

`interpolate_theta_forward` (`src/surface/interp.rs`) is a `pub(crate)` hot-path function called on every vol query for SSVI/eSSVI surfaces. Both callers validate inputs at construction time, so the preconditions are structurally guaranteed — but the function itself had no explicit guards.

`debug_assert!` is the right level: zero release overhead on a <100ns path, catches internal misuse in dev builds.

## Test plan

- [x] 830 lib tests pass (819 existing + 11 new)
- [x] Zero clippy warnings
- [x] `#[should_panic]` tests gated on `debug_assertions` (won't fail in `cargo test --release`)
- [x] All 4 code paths exercised: exact match, left extrapolation, right extrapolation, interpolation
- [x] Edge cases: single element, tolerance boundary (5e-11), log-linear forward (geometric blend)

Closes #53