### PR TITLE
feat!: use Strike/Tenor newtypes for all API inputs (v2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Production-ready volatility surface library for derivatives pricing"

--- a/benches/surface_construction.rs
+++ b/benches/surface_construction.rs
@@ -3,6 +3,7 @@ use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 use volsurf::smile::{SabrSmile, SmileSection, SviSmile};
 use volsurf::surface::{EssviSurface, SmileModel, SsviSurface, SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor};
 
 /// Generate synthetic SVI market data (strike, vol) pairs for benchmarking.
 fn generate_market_data(forward: f64, expiry: f64, n_strikes: usize) -> Vec<(f64, f64)> {
@@ -13,7 +14,7 @@ fn generate_market_data(forward: f64, expiry: f64, n_strikes: usize) -> Vec<(f64
     (0..n_strikes)
         .map(|i| {
             let k = k_min + (k_max - k_min) * (i as f64 / (n_strikes - 1) as f64);
-            let v = svi.vol(k).expect("SVI vol should succeed").0;
+            let v = svi.vol(Strike(k)).expect("SVI vol should succeed").0;
             (k, v)
         })
         .collect()
@@ -28,7 +29,7 @@ fn generate_sabr_market_data(forward: f64, expiry: f64, n_strikes: usize) -> Vec
     (0..n_strikes)
         .map(|i| {
             let k = k_min + (k_max - k_min) * (i as f64 / (n_strikes - 1) as f64);
-            let v = sabr.vol(k).expect("SABR vol should succeed").0;
+            let v = sabr.vol(Strike(k)).expect("SABR vol should succeed").0;
             (k, v)
         })
         .collect()
@@ -121,7 +122,7 @@ fn calibration_benchmarks(c: &mut Criterion) {
                 .map(|i| {
                     let k = k_min + (k_max - k_min) * (i as f64 / 9.0);
                     let v = ssvi_source
-                        .black_vol(t, k)
+                        .black_vol(Tenor(t), Strike(k))
                         .expect("SSVI vol should succeed")
                         .0;
                     (k, v)
@@ -164,7 +165,7 @@ fn calibration_benchmarks(c: &mut Criterion) {
                 .map(|i| {
                     let k = k_min + (k_max - k_min) * (i as f64 / 9.0);
                     let v = essvi_source
-                        .black_vol(t, k)
+                        .black_vol(Tenor(t), Strike(k))
                         .expect("eSSVI vol should succeed")
                         .0;
                     (k, v)
@@ -205,7 +206,7 @@ fn calibration_benchmarks(c: &mut Criterion) {
                 .map(|i| {
                     let k = k_min + (k_max - k_min) * (i as f64 / 9.0);
                     let v = flat_rho_source
-                        .black_vol(t, k)
+                        .black_vol(Tenor(t), Strike(k))
                         .expect("eSSVI vol should succeed")
                         .0;
                     (k, v)

--- a/benches/vol_query.rs
+++ b/benches/vol_query.rs
@@ -5,6 +5,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use volsurf::local_vol::{DupireLocalVol, LocalVol};
 use volsurf::smile::{SabrSmile, SmileSection, SplineSmile, SviSmile};
 use volsurf::surface::{PiecewiseSurface, SsviSurface, SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor};
 
 /// Build a realistic SviSmile for benchmarking (SPX-like 3M smile).
 fn make_svi_smile() -> SviSmile {
@@ -28,7 +29,7 @@ fn make_spline_smile() -> SplineSmile {
     let mut variances = Vec::with_capacity(n);
     for i in 0..n {
         let k = k_min + (k_max - k_min) * (i as f64 / (n - 1) as f64);
-        let v = svi.vol(k).expect("SVI vol should succeed").0;
+        let v = svi.vol(Strike(k)).expect("SVI vol should succeed").0;
         strikes.push(k);
         variances.push(v * v * 0.25); // variance = vol^2 * expiry
     }
@@ -55,7 +56,7 @@ fn make_surface() -> PiecewiseSurface {
             .collect();
         let vols: Vec<f64> = strikes
             .iter()
-            .map(|&k| svi.vol(k).expect("SVI vol should succeed").0)
+            .map(|&k| svi.vol(Strike(k)).expect("SVI vol should succeed").0)
             .collect();
         builder = builder.add_tenor(t, &strikes, &vols);
     }
@@ -78,41 +79,43 @@ fn smile_benchmarks(c: &mut Criterion) {
     // SVI vol query — pure arithmetic, target < 100ns
     let svi = make_svi_smile();
     group.bench_function("svi_vol_query", |b| {
-        b.iter(|| svi.vol(black_box(100.0)).unwrap());
+        b.iter(|| svi.vol(Strike(black_box(100.0))).unwrap());
     });
 
     // Spline vol query — binary search + cubic eval, target < 100ns
     let spline = make_spline_smile();
     group.bench_function("spline_vol_query", |b| {
-        b.iter(|| spline.vol(black_box(100.0)).unwrap());
+        b.iter(|| spline.vol(Strike(black_box(100.0))).unwrap());
     });
 
     // SABR vol query — Hagan formula with transcendentals, target < 100ns
     let sabr = make_sabr_smile();
     group.bench_function("sabr_vol_query", |b| {
-        b.iter(|| sabr.vol(black_box(100.0)).unwrap());
+        b.iter(|| sabr.vol(Strike(black_box(100.0))).unwrap());
     });
 
     // SABR density — Breeden-Litzenberger via finite differences
     group.bench_function("sabr_density", |b| {
-        b.iter(|| sabr.density(black_box(100.0)).unwrap());
+        b.iter(|| sabr.density(Strike(black_box(100.0))).unwrap());
     });
 
     // SVI density — Breeden-Litzenberger via finite differences
     group.bench_function("svi_density", |b| {
-        b.iter(|| svi.density(black_box(100.0)).unwrap());
+        b.iter(|| svi.density(Strike(black_box(100.0))).unwrap());
     });
 
     // Spline density — Breeden-Litzenberger via finite differences
     group.bench_function("spline_density", |b| {
-        b.iter(|| spline.density(black_box(100.0)).unwrap());
+        b.iter(|| spline.density(Strike(black_box(100.0))).unwrap());
     });
 
     // SSVI slice vol query via smile_at() — target < 100ns
     let ssvi = make_ssvi_surface();
-    let slice = ssvi.smile_at(0.25).expect("SSVI smile_at should succeed");
+    let slice = ssvi
+        .smile_at(Tenor(0.25))
+        .expect("SSVI smile_at should succeed");
     group.bench_function("ssvi_slice_vol_query", |b| {
-        b.iter(|| slice.vol(black_box(100.0)).unwrap());
+        b.iter(|| slice.vol(Strike(black_box(100.0))).unwrap());
     });
 
     group.finish();
@@ -126,7 +129,7 @@ fn surface_benchmarks(c: &mut Criterion) {
     group.bench_function("piecewise_vol_query", |b| {
         b.iter(|| {
             surface
-                .black_vol(black_box(0.375), black_box(105.0))
+                .black_vol(Tenor(black_box(0.375)), Strike(black_box(105.0)))
                 .unwrap()
         });
     });
@@ -134,15 +137,18 @@ fn surface_benchmarks(c: &mut Criterion) {
     // SSVI surface vol query — target < 100ns
     let ssvi = make_ssvi_surface();
     group.bench_function("ssvi_vol_query", |b| {
-        b.iter(|| ssvi.black_vol(black_box(0.375), black_box(105.0)).unwrap());
+        b.iter(|| {
+            ssvi.black_vol(Tenor(black_box(0.375)), Strike(black_box(105.0)))
+                .unwrap()
+        });
     });
 
     // --- smile_at construction ---
     group.bench_function("piecewise_smile_at", |b| {
-        b.iter(|| surface.smile_at(black_box(0.375)).unwrap());
+        b.iter(|| surface.smile_at(Tenor(black_box(0.375))).unwrap());
     });
     group.bench_function("ssvi_smile_at", |b| {
-        b.iter(|| ssvi.smile_at(black_box(0.375)).unwrap());
+        b.iter(|| ssvi.smile_at(Tenor(black_box(0.375))).unwrap());
     });
 
     // --- diagnostics ---
@@ -170,7 +176,7 @@ fn local_vol_benchmarks(c: &mut Criterion) {
     group.bench_function("dupire_single_query", |b| {
         b.iter(|| {
             dupire
-                .local_vol(black_box(0.375), black_box(105.0))
+                .local_vol(Tenor(black_box(0.375)), Strike(black_box(105.0)))
                 .unwrap()
         });
     });
@@ -182,7 +188,7 @@ fn local_vol_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             for &t in black_box(&expiries) {
                 for &k in black_box(&strikes) {
-                    let _ = dupire.local_vol(t, k).unwrap();
+                    let _ = dupire.local_vol(Tenor(t), Strike(k)).unwrap();
                 }
             }
         });
@@ -195,7 +201,7 @@ fn local_vol_benchmarks(c: &mut Criterion) {
     group.bench_function("dupire_fine_bump", |b| {
         b.iter(|| {
             dupire_fine
-                .local_vol(black_box(0.375), black_box(105.0))
+                .local_vol(Tenor(black_box(0.375)), Strike(black_box(105.0)))
                 .unwrap()
         });
     });

--- a/examples/basic_surface.rs
+++ b/examples/basic_surface.rs
@@ -10,6 +10,7 @@
 //! Run with: `cargo run --example basic_surface`
 
 use volsurf::surface::{SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------------------------------------------------------------
@@ -61,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for &t in &query_tenors {
         print!("{t:>8.2}");
         for &k in &query_strikes {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             print!("{:>10.2}%", vol.0 * 100.0);
         }
         println!();
@@ -74,8 +75,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n--- Vol/Variance consistency check ---\n");
     let t = 0.5;
     let k = 100.0;
-    let vol = surface.black_vol(t, k)?;
-    let var = surface.black_variance(t, k)?;
+    let vol = surface.black_vol(Tenor(t), Strike(k))?;
+    let var = surface.black_variance(Tenor(t), Strike(k))?;
     println!("At T={t}, K={k}:");
     println!("  vol      = {:.6}", vol.0);
     println!("  variance = {:.6}", var.0);
@@ -87,12 +88,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------------------------------------------------------------
 
     println!("\n--- Smile section at T=0.75 (interpolated) ---\n");
-    let smile = surface.smile_at(0.75)?;
+    let smile = surface.smile_at(Tenor(0.75))?;
     println!("Forward: {:.2}", smile.forward());
     println!("Expiry:  {:.2}", smile.expiry());
     for &k in &query_strikes {
-        let v = smile.vol(k)?;
-        let d = smile.density(k)?;
+        let v = smile.vol(Strike(k))?;
+        let d = smile.density(Strike(k))?;
         println!("  K={k:>6.0}  vol={:.4}  density={:.6}", v.0, d);
     }
 

--- a/examples/dividend_yield.rs
+++ b/examples/dividend_yield.rs
@@ -17,6 +17,7 @@
 //!
 //! Run with: cargo run --example dividend_yield
 
+use volsurf::Tenor;
 use volsurf::surface::{SmileModel, SurfaceBuilder, VolSurface};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -121,9 +122,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "-".repeat(58));
 
     for &(t, fwd_mkt) in forwards {
-        let f1 = surface_rate_only.smile_at(t)?.forward();
-        let f2 = surface_with_q.smile_at(t)?.forward();
-        let f3 = surface_pcp.smile_at(t)?.forward();
+        let f1 = surface_rate_only.smile_at(Tenor(t))?.forward();
+        let f2 = surface_with_q.smile_at(Tenor(t))?.forward();
+        let f3 = surface_pcp.smile_at(Tenor(t))?.forward();
         let err1 = f1 - fwd_mkt;
         let err2 = f2 - fwd_mkt;
         let err3 = f3 - fwd_mkt;

--- a/examples/essvi_slice.rs
+++ b/examples/essvi_slice.rs
@@ -2,8 +2,8 @@
 //!
 //! Run with: `cargo run --example essvi_slice`
 
-use volsurf::SmileSection;
 use volsurf::surface::{EssviSlice, SsviSlice};
+use volsurf::{SmileSection, Strike};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Typical equity parameters: 1Y tenor, 20% ATM vol → θ = 0.04
@@ -28,8 +28,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{:<10} {:>10} {:>12}", "Strike", "Vol (%)", "Variance");
     println!("{:-<10} {:-<10} {:-<12}", "", "", "");
     for &k in &[80.0, 85.0, 90.0, 95.0, 100.0, 105.0, 110.0, 115.0, 120.0] {
-        let vol = slice.vol(k)?;
-        let var = slice.variance(k)?;
+        let vol = slice.vol(Strike(k))?;
+        let var = slice.variance(Strike(k))?;
         println!("{:<10.0} {:>10.2} {:>12.6}", k, vol.0 * 100.0, var.0);
     }
     println!();
@@ -39,8 +39,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Equivalence Check (eSSVI vs SSVI, same ρ) ===");
     let mut max_diff = 0.0_f64;
     for &k in &[70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0] {
-        let v1 = slice.vol(k)?.0;
-        let v2 = ssvi.vol(k)?.0;
+        let v1 = slice.vol(Strike(k))?.0;
+        let v2 = ssvi.vol(Strike(k))?.0;
         let diff = (v1 - v2).abs();
         max_diff = max_diff.max(diff);
     }
@@ -63,8 +63,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let restored: EssviSlice = serde_json::from_str(&json)?;
     println!(
         "Round-trip ATM vol: {:.6} → {:.6}",
-        slice.vol(100.0)?.0,
-        restored.vol(100.0)?.0
+        slice.vol(Strike(100.0))?.0,
+        restored.vol(Strike(100.0))?.0
     );
     println!();
 
@@ -74,14 +74,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let long = EssviSlice::new(100.0, 2.0, -0.3, 0.6, 0.5, 0.08)?;
     println!(
         "1M  (ρ=-0.70): ATM vol = {:.2}%",
-        short.vol(100.0)?.0 * 100.0
+        short.vol(Strike(100.0))?.0 * 100.0
     );
     println!(
         "2Y  (ρ=-0.30): ATM vol = {:.2}%",
-        long.vol(100.0)?.0 * 100.0
+        long.vol(Strike(100.0))?.0 * 100.0
     );
-    let skew_short = short.vol(95.0)?.0 - short.vol(105.0)?.0;
-    let skew_long = long.vol(95.0)?.0 - long.vol(105.0)?.0;
+    let skew_short = short.vol(Strike(95.0))?.0 - short.vol(Strike(105.0))?.0;
+    let skew_long = long.vol(Strike(95.0))?.0 - long.vol(Strike(105.0))?.0;
     println!("1M  skew (95-105): {:.2} vol pts", skew_short * 100.0);
     println!("2Y  skew (95-105): {:.2} vol pts", skew_long * 100.0);
 

--- a/examples/sabr_smile.rs
+++ b/examples/sabr_smile.rs
@@ -11,6 +11,7 @@
 
 use volsurf::smile::{SabrSmile, SmileSection, SviSmile};
 use volsurf::surface::{SmileModel, SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------------------------------------------------------------
@@ -46,8 +47,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let strikes = [70.0, 80.0, 90.0, 95.0, 100.0, 105.0, 110.0, 120.0, 130.0];
     for &k in &strikes {
-        let vol = smile.vol(k)?;
-        let dens = smile.density(k)?;
+        let vol = smile.vol(Strike(k))?;
+        let dens = smile.density(Strike(k))?;
         println!("{k:>8.0} {:>9.4}% {dens:>12.6}", vol.0 * 100.0);
     }
 
@@ -72,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate synthetic market data from the known smile
     let market_vols: Vec<(f64, f64)> = strikes
         .iter()
-        .map(|&k| Ok((k, smile.vol(k)?.0)))
+        .map(|&k| Ok((k, smile.vol(Strike(k))?.0)))
         .collect::<Result<_, volsurf::VolSurfError>>()?;
 
     // Calibrate with beta=1.0 (same as original)
@@ -94,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compare vols
     let mut max_err: f64 = 0.0;
     for &(k, orig_vol) in &market_vols {
-        let cal_vol = calibrated.vol(k)?.0;
+        let cal_vol = calibrated.vol(Strike(k))?.0;
         max_err = max_err.max((orig_vol - cal_vol).abs());
     }
     println!("Max vol error: {max_err:.2e}");
@@ -114,8 +115,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "-".repeat(42));
 
     for &(k, _) in &market_vols {
-        let sabr_vol = smile.vol(k)?.0;
-        let svi_vol = svi.vol(k)?.0;
+        let sabr_vol = smile.vol(Strike(k))?.0;
+        let svi_vol = svi.vol(Strike(k))?.0;
         let diff_bp = (sabr_vol - svi_vol) * 10_000.0;
         println!(
             "{k:>8.0} {:>9.4}% {:>9.4}% {:>9.1}",
@@ -141,7 +142,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|&k| {
             SabrSmile::new(forward, 0.25, 0.3, 1.0, -0.3, 0.4)
                 .unwrap()
-                .vol(k)
+                .vol(Strike(k))
                 .unwrap()
                 .0
         })
@@ -152,7 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|&k| {
             SabrSmile::new(forward, 1.0, 0.25, 1.0, -0.25, 0.35)
                 .unwrap()
-                .vol(k)
+                .vol(Strike(k))
                 .unwrap()
                 .0
         })
@@ -163,7 +164,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|&k| {
             SabrSmile::new(forward, 2.0, 0.22, 1.0, -0.20, 0.30)
                 .unwrap()
-                .vol(k)
+                .vol(Strike(k))
                 .unwrap()
                 .0
         })
@@ -191,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for &t in &[0.25, 0.50, 1.00, 1.50, 2.00] {
         print!("{t:>8.2}");
         for &k in &[80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             print!("{:>10.2}%", vol.0 * 100.0);
         }
         println!();

--- a/examples/smile_models.rs
+++ b/examples/smile_models.rs
@@ -7,6 +7,7 @@
 //!
 //! Run with: `cargo run --example smile_models`
 
+use volsurf::Strike;
 use volsurf::smile::{SmileSection, SplineSmile, SviSmile};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -55,8 +56,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "-".repeat(48));
 
     for &(k, market_vol) in &market_data {
-        let svi_vol = svi.vol(k)?.0;
-        let spline_vol = spline.vol(k)?.0;
+        let svi_vol = svi.vol(Strike(k))?.0;
+        let spline_vol = spline.vol(Strike(k))?.0;
         println!("{k:>8.0} {market_vol:>11.4}% {svi_vol:>11.4}% {spline_vol:>11.4}%",);
     }
 
@@ -64,8 +65,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n{:>8} {:>12} {:>12}", "Strike", "SVI", "Spline");
     println!("{}", "-".repeat(35));
     for k in [75.0, 85.0, 97.5, 102.5, 115.0, 125.0] {
-        let svi_vol = svi.vol(k)?.0;
-        let spline_vol = spline.vol(k)?.0;
+        let svi_vol = svi.vol(Strike(k))?.0;
+        let spline_vol = spline.vol(Strike(k))?.0;
         println!("{k:>8.1} {svi_vol:>11.4}% {spline_vol:>11.4}%");
     }
 
@@ -92,8 +93,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------------------------------------------------------------
 
     println!("\n--- Risk-neutral density at ATM ---\n");
-    let svi_d = svi.density(100.0)?;
-    let spline_d = spline.density(100.0)?;
+    let svi_d = svi.density(Strike(100.0))?;
+    let spline_d = spline.density(Strike(100.0))?;
     println!("SVI density:    {svi_d:.6}");
     println!("Spline density: {spline_d:.6}");
 

--- a/examples/ssvi_surface.rs
+++ b/examples/ssvi_surface.rs
@@ -11,6 +11,7 @@
 //! Run with: `cargo run --example ssvi_surface`
 
 use volsurf::surface::{SsviSurface, SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------------------------------------------------------------
@@ -62,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for &t in &query_tenors {
         print!("{t:>8.2}");
         for &k in &query_strikes {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             print!("{:>8.2}%", vol.0 * 100.0);
         }
         println!();
@@ -75,8 +76,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n--- Vol/Variance consistency ---\n");
     let t = 0.5;
     let k = 100.0;
-    let vol = surface.black_vol(t, k)?;
-    let var = surface.black_variance(t, k)?;
+    let vol = surface.black_vol(Tenor(t), Strike(k))?;
+    let var = surface.black_variance(Tenor(t), Strike(k))?;
     println!(
         "At T={t}, K={k}: vol={:.6}, var={:.6}, vol^2*T={:.6}",
         vol.0,
@@ -91,9 +92,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n--- Smile sections ---\n");
 
     for &t in &[0.25, 1.0, 2.0] {
-        let smile = surface.smile_at(t)?;
-        let atm_vol = smile.vol(smile.forward())?;
-        let density = smile.density(smile.forward())?;
+        let smile = surface.smile_at(Tenor(t))?;
+        let atm_vol = smile.vol(Strike(smile.forward()))?;
+        let density = smile.density(Strike(smile.forward()))?;
         println!(
             "T={t:.2}: forward={:.2}, ATM vol={:.4}%, density={:.6}",
             smile.forward(),
@@ -103,11 +104,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Interpolated tenor (not in original data)
-    let smile_075 = surface.smile_at(0.75)?;
+    let smile_075 = surface.smile_at(Tenor(0.75))?;
     println!(
         "\nInterpolated T=0.75: forward={:.2}, ATM vol={:.4}%",
         smile_075.forward(),
-        smile_075.vol(smile_075.forward())?.0 * 100.0
+        smile_075.vol(Strike(smile_075.forward()))?.0 * 100.0
     );
 
     // ---------------------------------------------------------------
@@ -147,7 +148,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|&t| {
             cal_strikes
                 .iter()
-                .map(|&k| Ok((k, surface.black_vol(t, k)?.0)))
+                .map(|&k| Ok((k, surface.black_vol(Tenor(t), Strike(k))?.0)))
                 .collect::<Result<Vec<_>, volsurf::VolSurfError>>()
         })
         .collect::<Result<_, _>>()?;
@@ -171,8 +172,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut max_err: f64 = 0.0;
     for &t in &tenors {
         for &k in &cal_strikes {
-            let orig = surface.black_vol(t, k)?.0;
-            let cal = calibrated.black_vol(t, k)?.0;
+            let orig = surface.black_vol(Tenor(t), Strike(k))?.0;
+            let cal = calibrated.black_vol(Tenor(t), Strike(k))?.0;
             max_err = max_err.max((orig - cal).abs());
         }
     }
@@ -191,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for &t in &tenors {
         let vols: Vec<f64> = strikes_7
             .iter()
-            .map(|&k| surface.black_vol(t, k).unwrap().0)
+            .map(|&k| surface.black_vol(Tenor(t), Strike(k)).unwrap().0)
             .collect();
         builder = builder.add_tenor(t, &strikes_7, &vols);
     }
@@ -206,8 +207,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for &t in &[0.25, 1.0, 2.0] {
         for &k in &[90.0, 100.0, 110.0] {
-            let ssvi_vol = surface.black_vol(t, k)?.0;
-            let pw_vol = piecewise.black_vol(t, k)?.0;
+            let ssvi_vol = surface.black_vol(Tenor(t), Strike(k))?.0;
+            let pw_vol = piecewise.black_vol(Tenor(t), Strike(k))?.0;
             let diff_bp = (ssvi_vol - pw_vol) * 10_000.0;
             println!(
                 "{t:.2},{k:.0} {:>9.4}% {:>9.4}% {:>9.1}",

--- a/python/src/local_vol.rs
+++ b/python/src/local_vol.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use volsurf::local_vol::{DupireLocalVol, LocalVol};
+use volsurf::{Strike, Tenor};
 
 use crate::error::to_py_err;
 use crate::types::PySurface;
@@ -23,7 +24,7 @@ impl PyDupireLocalVol {
 
     fn local_vol(&self, expiry: f64, strike: f64) -> PyResult<f64> {
         self.inner
-            .local_vol(expiry, strike)
+            .local_vol(Tenor(expiry), Strike(strike))
             .map_err(to_py_err)
             .map(|v| v.0)
     }

--- a/python/src/smile.rs
+++ b/python/src/smile.rs
@@ -1,6 +1,7 @@
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use volsurf::Strike;
 use volsurf::smile::{SabrSmile, SmileSection, SplineSmile, SviSmile};
 
 use crate::error::to_py_err;
@@ -11,15 +12,15 @@ macro_rules! impl_smile_methods {
         #[pymethods]
         impl $name {
             fn vol(&self, strike: f64) -> PyResult<f64> {
-                Ok(self.inner.vol(strike).map_err(to_py_err)?.0)
+                Ok(self.inner.vol(Strike(strike)).map_err(to_py_err)?.0)
             }
 
             fn variance(&self, strike: f64) -> PyResult<f64> {
-                Ok(self.inner.variance(strike).map_err(to_py_err)?.0)
+                Ok(self.inner.variance(Strike(strike)).map_err(to_py_err)?.0)
             }
 
             fn density(&self, strike: f64) -> PyResult<f64> {
-                self.inner.density(strike).map_err(to_py_err)
+                self.inner.density(Strike(strike)).map_err(to_py_err)
             }
 
             #[getter]
@@ -58,7 +59,7 @@ macro_rules! impl_smile_methods {
                 let inner = &self.inner;
                 let data = py.detach(|| {
                     stk.iter()
-                        .map(|&k| inner.vol(k).map(|v| v.0))
+                        .map(|&k| inner.vol(Strike(k)).map(|v| v.0))
                         .collect::<Result<Vec<f64>, _>>()
                 });
                 Ok(data.map_err(to_py_err)?.into_pyarray(py))

--- a/python/src/surface.rs
+++ b/python/src/surface.rs
@@ -5,6 +5,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use volsurf::VolSurface;
 use volsurf::surface::{EssviSurface, PerTenorFit, SsviSurface, SurfaceBuilder};
+use volsurf::{Strike, Tenor};
 
 use crate::error::to_py_err;
 use crate::types::{PySmile, PySmileModel, PySurface, PySurfaceDiagnostics};
@@ -28,7 +29,7 @@ macro_rules! impl_vol_grid {
                     let mut out = Vec::with_capacity(nexp * nstk);
                     for &t in &exp {
                         for &k in &stk {
-                            out.push(inner.black_vol(t, k)?.0);
+                            out.push(inner.black_vol(Tenor(t), Strike(k))?.0);
                         }
                     }
                     Ok::<_, volsurf::VolSurfError>(out)
@@ -65,19 +66,23 @@ impl PySsviSurface {
     }
 
     fn black_vol(&self, expiry: f64, strike: f64) -> PyResult<f64> {
-        Ok(self.inner.black_vol(expiry, strike).map_err(to_py_err)?.0)
+        Ok(self
+            .inner
+            .black_vol(Tenor(expiry), Strike(strike))
+            .map_err(to_py_err)?
+            .0)
     }
 
     fn black_variance(&self, expiry: f64, strike: f64) -> PyResult<f64> {
         Ok(self
             .inner
-            .black_variance(expiry, strike)
+            .black_variance(Tenor(expiry), Strike(strike))
             .map_err(to_py_err)?
             .0)
     }
 
     fn smile_at(&self, expiry: f64) -> PyResult<PySmile> {
-        let smile = self.inner.smile_at(expiry).map_err(to_py_err)?;
+        let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_py_err)?;
         Ok(PySmile { inner: smile })
     }
 
@@ -202,19 +207,23 @@ impl PyEssviSurface {
     }
 
     fn black_vol(&self, expiry: f64, strike: f64) -> PyResult<f64> {
-        Ok(self.inner.black_vol(expiry, strike).map_err(to_py_err)?.0)
+        Ok(self
+            .inner
+            .black_vol(Tenor(expiry), Strike(strike))
+            .map_err(to_py_err)?
+            .0)
     }
 
     fn black_variance(&self, expiry: f64, strike: f64) -> PyResult<f64> {
         Ok(self
             .inner
-            .black_variance(expiry, strike)
+            .black_variance(Tenor(expiry), Strike(strike))
             .map_err(to_py_err)?
             .0)
     }
 
     fn smile_at(&self, expiry: f64) -> PyResult<PySmile> {
-        let smile = self.inner.smile_at(expiry).map_err(to_py_err)?;
+        let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_py_err)?;
         Ok(PySmile { inner: smile })
     }
 

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 use volsurf::smile::{ArbitrageReport, ButterflyViolation};
 use volsurf::surface::{CalendarViolation, SmileModel, SurfaceDiagnostics};
-use volsurf::{OptionType, SmileSection, VolSurface};
+use volsurf::{OptionType, SmileSection, Strike, Tenor, VolSurface};
 
 use crate::error::to_py_err;
 
@@ -80,15 +80,15 @@ pub struct PySmile {
 #[pymethods]
 impl PySmile {
     fn vol(&self, strike: f64) -> PyResult<f64> {
-        Ok(self.inner.vol(strike).map_err(to_py_err)?.0)
+        Ok(self.inner.vol(Strike(strike)).map_err(to_py_err)?.0)
     }
 
     fn variance(&self, strike: f64) -> PyResult<f64> {
-        Ok(self.inner.variance(strike).map_err(to_py_err)?.0)
+        Ok(self.inner.variance(Strike(strike)).map_err(to_py_err)?.0)
     }
 
     fn density(&self, strike: f64) -> PyResult<f64> {
-        self.inner.density(strike).map_err(to_py_err)
+        self.inner.density(Strike(strike)).map_err(to_py_err)
     }
 
     #[getter]
@@ -115,7 +115,7 @@ impl PySmile {
         let inner = &self.inner;
         let data = py.detach(|| {
             stk.iter()
-                .map(|&k| inner.vol(k).map(|v| v.0))
+                .map(|&k| inner.vol(Strike(k)).map(|v| v.0))
                 .collect::<Result<Vec<f64>, _>>()
         });
         Ok(data.map_err(to_py_err)?.into_pyarray(py))
@@ -131,19 +131,23 @@ pub struct PySurface {
 #[pymethods]
 impl PySurface {
     fn black_vol(&self, expiry: f64, strike: f64) -> PyResult<f64> {
-        Ok(self.inner.black_vol(expiry, strike).map_err(to_py_err)?.0)
+        Ok(self
+            .inner
+            .black_vol(Tenor(expiry), Strike(strike))
+            .map_err(to_py_err)?
+            .0)
     }
 
     fn black_variance(&self, expiry: f64, strike: f64) -> PyResult<f64> {
         Ok(self
             .inner
-            .black_variance(expiry, strike)
+            .black_variance(Tenor(expiry), Strike(strike))
             .map_err(to_py_err)?
             .0)
     }
 
     fn smile_at(&self, expiry: f64) -> PyResult<PySmile> {
-        let smile = self.inner.smile_at(expiry).map_err(to_py_err)?;
+        let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_py_err)?;
         Ok(PySmile { inner: smile })
     }
 
@@ -166,7 +170,7 @@ impl PySurface {
             let mut out = Vec::with_capacity(nexp * nstk);
             for &t in &exp {
                 for &k in &stk {
-                    out.push(inner.black_vol(t, k)?.0);
+                    out.push(inner.black_vol(Tenor(t), Strike(k))?.0);
                 }
             }
             Ok::<_, volsurf::VolSurfError>(out)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@
 //!
 //! ## Design
 //!
-//! - **Newtypes for outputs, bare `f64` for inputs.** [`Vol`], [`Variance`],
-//!   [`Strike`], [`Tenor`] wrap return values to prevent accidental mixing.
-//!   Inputs take raw `f64` for ergonomics — validation happens inside model
-//!   constructors and the builder.
+//! - **Newtypes for inputs and outputs.** [`Vol`], [`Variance`] wrap return
+//!   values to prevent accidental mixing. [`Strike`], [`Tenor`] wrap inputs
+//!   for compile-time parameter-swap safety — e.g.,
+//!   `black_vol(Tenor(0.5), Strike(100.0))` cannot be transposed.
 //! - **No panics.** Every fallible operation returns [`Result`]. Library code
 //!   never calls `unwrap()` or `expect()`.
 //! - **Immutable surfaces.** Once constructed, a surface cannot be modified.

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use crate::conventions::log_moneyness;
 use crate::error::{self, VolSurfError};
 use crate::surface::VolSurface;
-use crate::types::Vol;
+use crate::types::{Strike, Tenor, Vol};
 use crate::validate::validate_positive;
 
 use super::LocalVol;
@@ -70,51 +70,53 @@ impl LocalVol for DupireLocalVol {
     /// The time derivative is taken at constant log-moneyness y = ln(K/F),
     /// adjusting the strike at each bumped tenor to account for the
     /// changing forward.
-    fn local_vol(&self, expiry: f64, strike: f64) -> error::Result<Vol> {
-        validate_positive(expiry, "expiry")?;
-        validate_positive(strike, "strike")?;
+    fn local_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol> {
+        validate_positive(expiry.0, "expiry")?;
+        validate_positive(strike.0, "strike")?;
 
         let h = self.bump_size;
+        let t = expiry.0;
+        let k = strike.0;
 
         let smile = self.surface.smile_at(expiry)?;
         let fwd = smile.forward();
-        let y = log_moneyness(strike, fwd)?;
+        let y = log_moneyness(k, fwd)?;
 
         let w = self.surface.black_variance(expiry, strike)?.0;
         if w <= 0.0 {
             return Err(VolSurfError::NumericalError {
-                message: format!("non-positive total variance {w} at T={expiry}, K={strike}"),
+                message: format!("non-positive total variance {w} at T={t}, K={k}"),
             });
         }
 
         // Strike-space derivatives at fixed T (central differences in log-moneyness)
         let k_up = fwd * (y + h).exp();
         let k_dn = fwd * (y - h).exp();
-        let w_up = self.surface.black_variance(expiry, k_up)?.0;
-        let w_dn = self.surface.black_variance(expiry, k_dn)?.0;
+        let w_up = self.surface.black_variance(expiry, Strike(k_up))?.0;
+        let w_dn = self.surface.black_variance(expiry, Strike(k_dn))?.0;
 
         let dw_dy = (w_up - w_dn) / (2.0 * h);
         let d2w_dy2 = (w_up - 2.0 * w + w_dn) / (h * h);
 
         // Time derivative at constant y (forward adjustment at bumped tenors)
-        let dw_dt = if expiry > 2.0 * h {
-            let smile_up = self.surface.smile_at(expiry + h)?;
-            let smile_dn = self.surface.smile_at(expiry - h)?;
+        let dw_dt = if t > 2.0 * h {
+            let smile_up = self.surface.smile_at(Tenor(t + h))?;
+            let smile_dn = self.surface.smile_at(Tenor(t - h))?;
             let w_t_up = self
                 .surface
-                .black_variance(expiry + h, smile_up.forward() * y.exp())?
+                .black_variance(Tenor(t + h), Strike(smile_up.forward() * y.exp()))?
                 .0;
             let w_t_dn = self
                 .surface
-                .black_variance(expiry - h, smile_dn.forward() * y.exp())?
+                .black_variance(Tenor(t - h), Strike(smile_dn.forward() * y.exp()))?
                 .0;
             (w_t_up - w_t_dn) / (2.0 * h)
         } else {
             // Forward difference for short expiry where T - h would be non-positive
-            let smile_up = self.surface.smile_at(expiry + h)?;
+            let smile_up = self.surface.smile_at(Tenor(t + h))?;
             let w_t_up = self
                 .surface
-                .black_variance(expiry + h, smile_up.forward() * y.exp())?
+                .black_variance(Tenor(t + h), Strike(smile_up.forward() * y.exp()))?
                 .0;
             (w_t_up - w) / h
         };
@@ -127,7 +129,7 @@ impl LocalVol for DupireLocalVol {
         if denom <= 0.0 {
             return Err(VolSurfError::NumericalError {
                 message: format!(
-                    "non-positive denominator {denom} at T={expiry}, K={strike} \
+                    "non-positive denominator {denom} at T={t}, K={k} \
                      (butterfly arbitrage)"
                 ),
             });
@@ -137,7 +139,7 @@ impl LocalVol for DupireLocalVol {
         if v_local < 0.0 {
             return Err(VolSurfError::NumericalError {
                 message: format!(
-                    "negative local variance {v_local} at T={expiry}, K={strike} \
+                    "negative local variance {v_local} at T={t}, K={k} \
                      (calendar arbitrage)"
                 ),
             });
@@ -153,19 +155,19 @@ mod tests {
     use crate::smile::SmileSection;
     use crate::smile::arbitrage::ArbitrageReport;
     use crate::surface::arbitrage::SurfaceDiagnostics;
-    use crate::types::Variance;
+    use crate::types::{Strike, Tenor, Variance};
 
     #[derive(Debug)]
     struct StubSurface;
 
     impl VolSurface for StubSurface {
-        fn black_vol(&self, _: f64, _: f64) -> error::Result<Vol> {
+        fn black_vol(&self, _: Tenor, _: Strike) -> error::Result<Vol> {
             Ok(Vol(0.2))
         }
-        fn black_variance(&self, _: f64, _: f64) -> error::Result<Variance> {
+        fn black_variance(&self, _: Tenor, _: Strike) -> error::Result<Variance> {
             Ok(Variance(0.04))
         }
-        fn smile_at(&self, _: f64) -> error::Result<Box<dyn SmileSection>> {
+        fn smile_at(&self, _: Tenor) -> error::Result<Box<dyn SmileSection>> {
             unimplemented!()
         }
         fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
@@ -192,10 +194,10 @@ mod tests {
     }
 
     impl SmileSection for FlatSmile {
-        fn vol(&self, _: f64) -> error::Result<Vol> {
+        fn vol(&self, _: Strike) -> error::Result<Vol> {
             Ok(Vol(self.sigma))
         }
-        fn variance(&self, _: f64) -> error::Result<Variance> {
+        fn variance(&self, _: Strike) -> error::Result<Variance> {
             Ok(Variance(self.sigma * self.sigma * self.expiry))
         }
         fn forward(&self) -> f64 {
@@ -204,7 +206,7 @@ mod tests {
         fn expiry(&self) -> f64 {
             self.expiry
         }
-        fn density(&self, _: f64) -> error::Result<f64> {
+        fn density(&self, _: Strike) -> error::Result<f64> {
             unimplemented!()
         }
         fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
@@ -213,17 +215,17 @@ mod tests {
     }
 
     impl VolSurface for FlatVolSurface {
-        fn black_vol(&self, _: f64, _: f64) -> error::Result<Vol> {
+        fn black_vol(&self, _: Tenor, _: Strike) -> error::Result<Vol> {
             Ok(Vol(self.sigma))
         }
-        fn black_variance(&self, expiry: f64, _: f64) -> error::Result<Variance> {
-            Ok(Variance(self.sigma * self.sigma * expiry))
+        fn black_variance(&self, expiry: Tenor, _: Strike) -> error::Result<Variance> {
+            Ok(Variance(self.sigma * self.sigma * expiry.0))
         }
-        fn smile_at(&self, expiry: f64) -> error::Result<Box<dyn SmileSection>> {
+        fn smile_at(&self, expiry: Tenor) -> error::Result<Box<dyn SmileSection>> {
             Ok(Box::new(FlatSmile {
                 sigma: self.sigma,
                 fwd: self.fwd,
-                expiry,
+                expiry: expiry.0,
             }))
         }
         fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
@@ -297,28 +299,28 @@ mod tests {
         let lv = DupireLocalVol::new(flat_surface(sigma));
 
         // ATM
-        let v = lv.local_vol(0.5, 100.0).unwrap();
+        let v = lv.local_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!((v.0 - sigma).abs() < 1e-10, "ATM: got {}", v.0);
 
         // OTM
-        let v = lv.local_vol(1.0, 120.0).unwrap();
+        let v = lv.local_vol(Tenor(1.0), Strike(120.0)).unwrap();
         assert!((v.0 - sigma).abs() < 1e-10, "OTM: got {}", v.0);
 
         // ITM
-        let v = lv.local_vol(0.25, 80.0).unwrap();
+        let v = lv.local_vol(Tenor(0.25), Strike(80.0)).unwrap();
         assert!((v.0 - sigma).abs() < 1e-10, "ITM: got {}", v.0);
     }
 
     #[test]
     fn rejects_zero_expiry() {
         let lv = DupireLocalVol::new(flat_surface(0.2));
-        assert!(lv.local_vol(0.0, 100.0).is_err());
+        assert!(lv.local_vol(Tenor(0.0), Strike(100.0)).is_err());
     }
 
     #[test]
     fn rejects_zero_strike() {
         let lv = DupireLocalVol::new(flat_surface(0.2));
-        assert!(lv.local_vol(0.5, 0.0).is_err());
+        assert!(lv.local_vol(Tenor(0.5), Strike(0.0)).is_err());
     }
 
     // Gatheral (1.10) at y=0: denominator simplifies because (y/w)*dw_dy = 0
@@ -341,7 +343,7 @@ mod tests {
         let surface = Arc::new(PiecewiseSurface::new(vec![t1, t2], vec![s1, s2]).unwrap());
 
         let dupire = DupireLocalVol::new(surface);
-        let v = dupire.local_vol(1.0, 100.0).unwrap();
+        let v = dupire.local_vol(Tenor(1.0), Strike(100.0)).unwrap();
 
         // Analytical at ATM (y=0, m=0):
         // w = 0.5*(a1 + b*sigma) + 0.5*(a2 + b*sigma)
@@ -390,7 +392,7 @@ mod tests {
         let k = 110.0_f64;
         let y = (k / fwd).ln();
         let dupire = DupireLocalVol::new(surface);
-        let v = dupire.local_vol(1.0, k).unwrap();
+        let v = dupire.local_vol(Tenor(1.0), Strike(k)).unwrap();
 
         // SVI analytical derivatives at y = ln(110/100) ≈ 0.09531
         let dk = y - m;
@@ -432,10 +434,10 @@ mod tests {
         struct ZeroFwdSmile;
 
         impl SmileSection for ZeroFwdSmile {
-            fn vol(&self, _: f64) -> error::Result<Vol> {
+            fn vol(&self, _: Strike) -> error::Result<Vol> {
                 Ok(Vol(0.2))
             }
-            fn variance(&self, _: f64) -> error::Result<Variance> {
+            fn variance(&self, _: Strike) -> error::Result<Variance> {
                 Ok(Variance(0.01))
             }
             fn forward(&self) -> f64 {
@@ -444,7 +446,7 @@ mod tests {
             fn expiry(&self) -> f64 {
                 0.5
             }
-            fn density(&self, _: f64) -> error::Result<f64> {
+            fn density(&self, _: Strike) -> error::Result<f64> {
                 unimplemented!()
             }
             fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
@@ -453,13 +455,13 @@ mod tests {
         }
 
         impl VolSurface for ZeroFwdSurface {
-            fn black_vol(&self, _: f64, _: f64) -> error::Result<Vol> {
+            fn black_vol(&self, _: Tenor, _: Strike) -> error::Result<Vol> {
                 Ok(Vol(0.2))
             }
-            fn black_variance(&self, _: f64, _: f64) -> error::Result<Variance> {
+            fn black_variance(&self, _: Tenor, _: Strike) -> error::Result<Variance> {
                 Ok(Variance(0.01))
             }
-            fn smile_at(&self, _: f64) -> error::Result<Box<dyn SmileSection>> {
+            fn smile_at(&self, _: Tenor) -> error::Result<Box<dyn SmileSection>> {
                 Ok(Box::new(ZeroFwdSmile))
             }
             fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
@@ -468,7 +470,7 @@ mod tests {
         }
 
         let dupire = DupireLocalVol::new(Arc::new(ZeroFwdSurface));
-        let err = dupire.local_vol(0.5, 100.0).unwrap_err();
+        let err = dupire.local_vol(Tenor(0.5), Strike(100.0)).unwrap_err();
         assert!(
             matches!(err, VolSurfError::InvalidInput { .. }),
             "expected InvalidInput from log_moneyness, got {err:?}"
@@ -480,7 +482,7 @@ mod tests {
         // T=0.015 < 2*h (h=0.01), uses forward difference path
         let sigma = 0.20;
         let lv = DupireLocalVol::new(flat_surface(sigma));
-        let v = lv.local_vol(0.015, 100.0).unwrap();
+        let v = lv.local_vol(Tenor(0.015), Strike(100.0)).unwrap();
         assert!((v.0 - sigma).abs() < 1e-10, "short T: got {}", v.0);
     }
 }

--- a/src/local_vol/mod.rs
+++ b/src/local_vol/mod.rs
@@ -17,7 +17,7 @@ pub mod dupire;
 pub use dupire::DupireLocalVol;
 
 use crate::error;
-use crate::types::Vol;
+use crate::types::{Strike, Tenor, Vol};
 
 /// Local volatility surface: σ_loc(T, K).
 ///
@@ -27,5 +27,5 @@ use crate::types::Vol;
 /// around any `Arc<dyn VolSurface>`.
 pub trait LocalVol: Send + Sync + std::fmt::Debug {
     /// Local volatility at the given expiry and strike.
-    fn local_vol(&self, expiry: f64, strike: f64) -> error::Result<Vol>;
+    fn local_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol>;
 }

--- a/src/smile/mod.rs
+++ b/src/smile/mod.rs
@@ -23,7 +23,7 @@ pub(crate) const BUTTERFLY_G_TOL: f64 = 1e-10;
 
 use crate::error;
 use crate::implied::black::black_price;
-use crate::types::{OptionType, Variance, Vol};
+use crate::types::{OptionType, Strike, Variance, Vol};
 use crate::validate::validate_positive;
 
 /// A single-tenor volatility smile.
@@ -53,14 +53,15 @@ use crate::validate::validate_positive;
 ///
 /// ```
 /// use volsurf::smile::{SabrSmile, SmileSection};
+/// use volsurf::types::Strike;
 ///
 /// // Create a concrete smile and use it through the trait interface
 /// let smile = SabrSmile::new(100.0, 1.0, 0.3, 1.0, -0.3, 0.4)?;
 ///
-/// let vol = smile.vol(100.0)?;
+/// let vol = smile.vol(Strike(100.0))?;
 /// assert!(vol.0 > 0.0);
 ///
-/// let var = smile.variance(100.0)?;
+/// let var = smile.variance(Strike(100.0))?;
 /// assert!((var.0 - vol.0 * vol.0 * smile.expiry()).abs() < 1e-12);
 ///
 /// let report = smile.is_arbitrage_free()?;
@@ -69,13 +70,13 @@ use crate::validate::validate_positive;
 /// ```
 pub trait SmileSection: Send + Sync + std::fmt::Debug {
     /// Implied Black volatility σ at the given strike.
-    fn vol(&self, strike: f64) -> error::Result<Vol>;
+    fn vol(&self, strike: Strike) -> error::Result<Vol>;
 
     /// Total Black variance σ²T at the given strike.
     ///
     /// Default implementation derives from [`vol`](SmileSection::vol):
     /// `variance(K) = vol(K)² × expiry`.
-    fn variance(&self, strike: f64) -> error::Result<Variance> {
+    fn variance(&self, strike: Strike) -> error::Result<Variance> {
         let v = self.vol(strike)?;
         Ok(Variance(v.0 * v.0 * self.expiry()))
     }
@@ -87,16 +88,16 @@ pub trait SmileSection: Send + Sync + std::fmt::Debug {
     ///
     /// Models with analytical density (e.g., SVI via the g-function) should
     /// override this for better accuracy and performance.
-    fn density(&self, strike: f64) -> error::Result<f64> {
-        validate_positive(strike, "strike")?;
+    fn density(&self, strike: Strike) -> error::Result<f64> {
+        validate_positive(strike.0, "strike")?;
         // Relative perturbation for central finite difference
-        let h = strike * 1e-4;
-        let k_lo = strike - h;
-        let k_hi = strike + h;
+        let h = strike.0 * 1e-4;
+        let k_lo = strike.0 - h;
+        let k_hi = strike.0 + h;
 
-        let v_lo = self.vol(k_lo)?;
+        let v_lo = self.vol(Strike(k_lo))?;
         let v_mid = self.vol(strike)?;
-        let v_hi = self.vol(k_hi)?;
+        let v_hi = self.vol(Strike(k_hi))?;
 
         let c_lo = black_price(
             self.forward(),
@@ -107,7 +108,7 @@ pub trait SmileSection: Send + Sync + std::fmt::Debug {
         )?;
         let c_mid = black_price(
             self.forward(),
-            strike,
+            strike.0,
             v_mid.0,
             self.expiry(),
             OptionType::Call,

--- a/src/smile/sabr.rs
+++ b/src/smile/sabr.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{self, VolSurfError};
 use crate::smile::SmileSection;
 use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
-use crate::types::Vol;
+use crate::types::{Strike, Vol};
 use crate::validate::{validate_non_negative, validate_positive};
 
 const TAYLOR_Z_TOL: f64 = 1e-6;
@@ -65,9 +65,10 @@ const TAYLOR_Z_TOL: f64 = 1e-6;
 ///
 /// ```
 /// use volsurf::smile::{SabrSmile, SmileSection};
+/// use volsurf::types::Strike;
 ///
 /// let smile = SabrSmile::new(100.0, 1.0, 0.3, 1.0, -0.3, 0.4)?;
-/// let vol = smile.vol(100.0)?; // ATM vol
+/// let vol = smile.vol(Strike(100.0))?; // ATM vol
 /// assert!(vol.0 > 0.0);
 /// # Ok::<(), volsurf::VolSurfError>(())
 /// ```
@@ -264,13 +265,14 @@ impl SabrSmile {
     ///
     /// ```
     /// use volsurf::smile::{SabrSmile, SmileSection};
+    /// use volsurf::types::Strike;
     ///
     /// let market_vols = vec![
     ///     (80.0, 0.28), (90.0, 0.24), (100.0, 0.20),
     ///     (110.0, 0.22), (120.0, 0.26),
     /// ];
     /// let smile = SabrSmile::calibrate(100.0, 1.0, 0.5, &market_vols)?;
-    /// let vol = smile.vol(100.0)?;
+    /// let vol = smile.vol(Strike(100.0))?;
     /// assert!((vol.0 - 0.20).abs() < 0.01);
     /// # Ok::<(), volsurf::VolSurfError>(())
     /// ```
@@ -489,9 +491,9 @@ fn interpolate_atm_vol(forward: f64, market_vols: &[(f64, f64)]) -> f64 {
 }
 
 impl SmileSection for SabrSmile {
-    fn vol(&self, strike: f64) -> error::Result<Vol> {
-        validate_positive(strike, "strike")?;
-        let sigma = self.hagan_implied_vol(strike);
+    fn vol(&self, strike: Strike) -> error::Result<Vol> {
+        validate_positive(strike.0, "strike")?;
+        let sigma = self.hagan_implied_vol(strike.0);
         if sigma < 0.0 || !sigma.is_finite() {
             return Err(VolSurfError::NumericalError {
                 message: format!(
@@ -524,7 +526,7 @@ impl SmileSection for SabrSmile {
         for i in 0..N {
             let k = K_MIN + (K_MAX - K_MIN) * (i as f64) / ((N - 1) as f64);
             let strike = self.forward * k.exp();
-            let d = match self.density(strike) {
+            let d = match self.density(Strike(strike)) {
                 Ok(d) => d,
                 Err(_) => continue, // Hagan breakdown in wings
             };
@@ -848,7 +850,7 @@ mod tests {
     #[test]
     fn vol_atm_returns_positive() {
         let s = make_equity_smile();
-        let v = s.vol(F).unwrap();
+        let v = s.vol(Strike(F)).unwrap();
         assert!(v.0 > 0.0, "ATM vol should be positive, got {}", v.0);
     }
 
@@ -863,7 +865,7 @@ mod tests {
                 + T * (omb * omb / 24.0 * EQ_ALPHA * EQ_ALPHA / (f_omb * f_omb)
                     + 0.25 * RHO * BETA * NU * EQ_ALPHA / f_omb
                     + (2.0 - 3.0 * RHO * RHO) / 24.0 * NU * NU));
-        let actual = s.vol(F).unwrap().0;
+        let actual = s.vol(Strike(F)).unwrap().0;
         assert!(
             (actual - expected).abs() < 1e-14,
             "ATM vol mismatch: expected {expected}, got {actual}"
@@ -873,14 +875,14 @@ mod tests {
     #[test]
     fn vol_otm_call() {
         let s = make_equity_smile();
-        let v = s.vol(120.0).unwrap();
+        let v = s.vol(Strike(120.0)).unwrap();
         assert!(v.0 > 0.0, "OTM call vol should be positive");
     }
 
     #[test]
     fn vol_itm_call() {
         let s = make_equity_smile();
-        let v = s.vol(80.0).unwrap();
+        let v = s.vol(Strike(80.0)).unwrap();
         assert!(v.0 > 0.0, "ITM call vol should be positive");
     }
 
@@ -890,10 +892,10 @@ mod tests {
         // is continuous through K = F. Verify the second-order finite difference
         // is bounded (C² smoothness ⇒ no discontinuity or kink at ATM).
         let s = make_equity_smile();
-        let v_atm = s.vol(F).unwrap().0;
+        let v_atm = s.vol(Strike(F)).unwrap().0;
         for &h in &[1.0, 0.1, 0.01] {
-            let v_above = s.vol(F + h).unwrap().0;
-            let v_below = s.vol(F - h).unwrap().0;
+            let v_above = s.vol(Strike(F + h)).unwrap().0;
+            let v_below = s.vol(Strike(F - h)).unwrap().0;
             let curvature = (v_above + v_below - 2.0 * v_atm) / (h * h);
             // Bounded curvature ⇒ no discontinuity
             assert!(
@@ -905,9 +907,9 @@ mod tests {
         // z = (ν/α) * fk_mid * ln(F/K). At the boundary |z|=1e-6, the Taylor
         // and exact formulas agree to ~1e-13, so no switching discontinuity.
         let z_boundary_k = F * (-5e-7_f64).exp(); // z ≈ 1e-6
-        let v1 = s.vol(z_boundary_k).unwrap().0;
-        let v2 = s.vol(z_boundary_k * 0.999).unwrap().0;
-        let v3 = s.vol(z_boundary_k * 1.001).unwrap().0;
+        let v1 = s.vol(Strike(z_boundary_k)).unwrap().0;
+        let v2 = s.vol(Strike(z_boundary_k * 0.999)).unwrap().0;
+        let v3 = s.vol(Strike(z_boundary_k * 1.001)).unwrap().0;
         let curvature = (v2 + v3 - 2.0 * v1) / ((z_boundary_k * 0.001).powi(2));
         assert!(
             curvature.abs() < 100.0,
@@ -920,7 +922,7 @@ mod tests {
         // beta=0: normal SABR, ATM vol ≈ alpha/F
         let alpha = 10.0; // gives ~10% vol with F=100
         let s = SabrSmile::new(F, T, alpha, 0.0, RHO, NU).unwrap();
-        let v = s.vol(F).unwrap().0;
+        let v = s.vol(Strike(F)).unwrap().0;
         let expected_approx = alpha / F; // 0.10
         // Should be close to alpha/F (within the correction term)
         assert!(
@@ -928,8 +930,8 @@ mod tests {
             "Normal SABR ATM vol ≈ α/F = {expected_approx}, got {v}"
         );
         // OTM should also work
-        assert!(s.vol(110.0).unwrap().0 > 0.0);
-        assert!(s.vol(90.0).unwrap().0 > 0.0);
+        assert!(s.vol(Strike(110.0)).unwrap().0 > 0.0);
+        assert!(s.vol(Strike(90.0)).unwrap().0 > 0.0);
     }
 
     #[test]
@@ -937,7 +939,7 @@ mod tests {
         // beta=1: lognormal SABR, ATM vol ≈ alpha
         let alpha = 0.20;
         let s = SabrSmile::new(F, T, alpha, 1.0, RHO, NU).unwrap();
-        let v = s.vol(F).unwrap().0;
+        let v = s.vol(Strike(F)).unwrap().0;
         // σ_ATM = α * [1 + T*(¼ρνα + (2-3ρ²)/24*ν²)]
         let expected = alpha
             * (1.0 + T * (0.25 * RHO * NU * alpha + (2.0 - 3.0 * RHO * RHO) / 24.0 * NU * NU));
@@ -951,7 +953,7 @@ mod tests {
     fn vol_nu_zero_cev_limit() {
         // nu=0: z/x(z) = 1, no vol-of-vol terms
         let s = SabrSmile::new(F, T, EQ_ALPHA, BETA, RHO, 0.0).unwrap();
-        let v_atm = s.vol(F).unwrap().0;
+        let v_atm = s.vol(Strike(F)).unwrap().0;
         let omb = 1.0 - BETA;
         let f_omb = F.powf(omb);
         // Only the (1-β)²/24 * α²/F^(2(1-β)) term survives
@@ -968,9 +970,9 @@ mod tests {
         // beta=1, nu=0: pure lognormal, constant vol = alpha for all strikes
         let alpha = 0.20;
         let s = SabrSmile::new(F, T, alpha, 1.0, 0.0, 0.0).unwrap();
-        let v_atm = s.vol(F).unwrap().0;
-        let v_otm = s.vol(120.0).unwrap().0;
-        let v_itm = s.vol(80.0).unwrap().0;
+        let v_atm = s.vol(Strike(F)).unwrap().0;
+        let v_otm = s.vol(Strike(120.0)).unwrap().0;
+        let v_itm = s.vol(Strike(80.0)).unwrap().0;
         assert!(
             (v_atm - alpha).abs() < 1e-14,
             "β=1,ν=0 ATM should be α={alpha}, got {v_atm}"
@@ -991,8 +993,8 @@ mod tests {
         let alpha = 0.20;
         let s = SabrSmile::new(F, T, alpha, 1.0, 0.0, NU).unwrap();
         let ratio = 1.2;
-        let v_up = s.vol(F * ratio).unwrap().0;
-        let v_down = s.vol(F / ratio).unwrap().0;
+        let v_up = s.vol(Strike(F * ratio)).unwrap().0;
+        let v_down = s.vol(Strike(F / ratio)).unwrap().0;
         // With beta=1 and rho=0, the smile is exactly symmetric in ln(K/F)
         assert!(
             (v_up - v_down).abs() < 1e-12,
@@ -1005,8 +1007,8 @@ mod tests {
     fn vol_negative_rho_skew() {
         // Negative rho: vol(K<F) > vol(K>F) (equity skew)
         let s = SabrSmile::new(F, T, EQ_ALPHA, BETA, -0.5, NU).unwrap();
-        let v_low = s.vol(80.0).unwrap().0;
-        let v_high = s.vol(120.0).unwrap().0;
+        let v_low = s.vol(Strike(80.0)).unwrap().0;
+        let v_high = s.vol(Strike(120.0)).unwrap().0;
         assert!(
             v_low > v_high,
             "Negative rho should produce downward skew: vol(80)={v_low} should > vol(120)={v_high}"
@@ -1016,14 +1018,17 @@ mod tests {
     #[test]
     fn vol_rejects_zero_strike() {
         let s = make_equity_smile();
-        assert!(matches!(s.vol(0.0), Err(VolSurfError::InvalidInput { .. })));
+        assert!(matches!(
+            s.vol(Strike(0.0)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
     }
 
     #[test]
     fn vol_rejects_negative_strike() {
         let s = make_equity_smile();
         assert!(matches!(
-            s.vol(-10.0),
+            s.vol(Strike(-10.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -1032,7 +1037,7 @@ mod tests {
     fn vol_rejects_nan_strike() {
         let s = make_equity_smile();
         assert!(matches!(
-            s.vol(f64::NAN),
+            s.vol(Strike(f64::NAN)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -1042,8 +1047,8 @@ mod tests {
         // variance() = vol()² * T (from SmileSection default impl)
         let s = make_equity_smile();
         let strike = 110.0;
-        let v = s.vol(strike).unwrap().0;
-        let var = s.variance(strike).unwrap().0;
+        let v = s.vol(Strike(strike)).unwrap().0;
+        let var = s.variance(Strike(strike)).unwrap().0;
         let expected_var = v * v * T;
         assert!(
             (var - expected_var).abs() < 1e-14,
@@ -1061,8 +1066,8 @@ mod tests {
         // z = (nu/alpha) * fk_mid * ln(F/K)
         // For small z, K must be very close to F
         let k_offset = 1e-4;
-        let v1 = s.vol(F + k_offset).unwrap().0;
-        let v2 = s.vol(F + k_offset * 1.01).unwrap().0;
+        let v1 = s.vol(Strike(F + k_offset)).unwrap().0;
+        let v2 = s.vol(Strike(F + k_offset * 1.01)).unwrap().0;
         // Should be smooth (no discontinuity)
         assert!(
             (v1 - v2).abs() < 1e-8,
@@ -1075,9 +1080,9 @@ mod tests {
         let smile = make_smile();
         let k_inside = F * (-5e-8_f64).exp();
         let k_outside = F * (-5e-5_f64).exp();
-        let v_inside = smile.vol(k_inside).unwrap().0;
-        let v_outside = smile.vol(k_outside).unwrap().0;
-        let v_atm = smile.vol(F).unwrap().0;
+        let v_inside = smile.vol(Strike(k_inside)).unwrap().0;
+        let v_outside = smile.vol(Strike(k_outside)).unwrap().0;
+        let v_atm = smile.vol(Strike(F)).unwrap().0;
         assert!(v_inside.is_finite());
         assert!(
             (v_inside - v_atm).abs() < 1e-6,
@@ -1093,7 +1098,7 @@ mod tests {
     fn vol_nu_zero_otm_strikes() {
         let smile = SabrSmile::new(F, T, ALPHA, BETA, 0.0, 0.0).unwrap();
         for &k in &[80.0, 90.0, 100.0, 110.0, 120.0] {
-            let v = smile.vol(k).unwrap().0;
+            let v = smile.vol(Strike(k)).unwrap().0;
             assert!(
                 v > 0.01 && v < 1.0,
                 "nu=0 vol at K={k} should be in (0.01, 1.0), got {v}"
@@ -1106,16 +1111,16 @@ mod tests {
         // rho = ±0.999: should still produce valid vols
         let s_pos = SabrSmile::new(F, T, EQ_ALPHA, BETA, 0.999, NU).unwrap();
         let s_neg = SabrSmile::new(F, T, EQ_ALPHA, BETA, -0.999, NU).unwrap();
-        assert!(s_pos.vol(F).unwrap().0 > 0.0);
-        assert!(s_neg.vol(F).unwrap().0 > 0.0);
-        assert!(s_pos.vol(110.0).unwrap().0 > 0.0);
-        assert!(s_neg.vol(110.0).unwrap().0 > 0.0);
+        assert!(s_pos.vol(Strike(F)).unwrap().0 > 0.0);
+        assert!(s_neg.vol(Strike(F)).unwrap().0 > 0.0);
+        assert!(s_pos.vol(Strike(110.0)).unwrap().0 > 0.0);
+        assert!(s_neg.vol(Strike(110.0)).unwrap().0 > 0.0);
     }
 
     #[test]
     fn vol_short_expiry() {
         let s = SabrSmile::new(F, 0.01, EQ_ALPHA, BETA, RHO, NU).unwrap();
-        let v = s.vol(F).unwrap().0;
+        let v = s.vol(Strike(F)).unwrap().0;
         let omb = 1.0 - BETA;
         let f_omb = F.powf(omb);
         // Short expiry: correction ≈ 1, so vol ≈ α/F^(1-β)
@@ -1129,11 +1134,11 @@ mod tests {
     #[test]
     fn vol_long_expiry() {
         let s = SabrSmile::new(F, 5.0, EQ_ALPHA, BETA, RHO, NU).unwrap();
-        let v = s.vol(F).unwrap().0;
+        let v = s.vol(Strike(F)).unwrap().0;
         assert!(v > 0.0, "Long expiry vol should be positive, got {v}");
         // Longer expiry has larger correction → vol should differ from short expiry
         let s_short = SabrSmile::new(F, 0.01, EQ_ALPHA, BETA, RHO, NU).unwrap();
-        let v_short = s_short.vol(F).unwrap().0;
+        let v_short = s_short.vol(Strike(F)).unwrap().0;
         assert!(
             (v - v_short).abs() > 0.001,
             "Long vs short expiry ATM vol should differ"
@@ -1146,7 +1151,7 @@ mod tests {
     fn vol_negative_correction_clamped_t20() {
         let s = SabrSmile::new(100.0, 20.0, 0.3, 0.5, -0.95, 1.5).unwrap();
         for &k in &[80.0, 100.0, 120.0] {
-            let v = s.vol(k);
+            let v = s.vol(Strike(k));
             assert!(v.is_ok(), "T=20, K={k}: should not return NumericalError");
             let vol = v.unwrap().0;
             assert!(vol > 0.0, "T=20, K={k}: vol must be positive");
@@ -1160,7 +1165,7 @@ mod tests {
     #[test]
     fn vol_negative_correction_clamped_t10() {
         let s = SabrSmile::new(100.0, 10.0, 0.3, 0.5, -0.95, 1.5).unwrap();
-        let v = s.vol(100.0).unwrap().0;
+        let v = s.vol(Strike(100.0)).unwrap().0;
         assert!(v > 0.0, "T=10, ATM vol must be positive, got {v}");
         assert!(v.is_finite(), "T=10, ATM vol must be finite");
     }
@@ -1171,8 +1176,8 @@ mod tests {
         // Vol should degrade monotonically — no discontinuity at the clamp.
         let s8 = SabrSmile::new(100.0, 8.0, 0.3, 0.5, -0.95, 1.5).unwrap();
         let s12 = SabrSmile::new(100.0, 12.0, 0.3, 0.5, -0.95, 1.5).unwrap();
-        let v8 = s8.vol(100.0).unwrap().0;
-        let v12 = s12.vol(100.0).unwrap().0;
+        let v8 = s8.vol(Strike(100.0)).unwrap().0;
+        let v12 = s12.vol(Strike(100.0)).unwrap().0;
         assert!(
             v8 > v12,
             "vol should decrease as T increases past the boundary"
@@ -1185,7 +1190,7 @@ mod tests {
         // beta=1 (lognormal): omb=0 kills two correction terms, only (2-3ρ²)/24·ν²
         // remains. Clamp should still fire for extreme ρ and long T.
         let s = SabrSmile::new(100.0, 20.0, 0.20, 1.0, -0.95, 1.5).unwrap();
-        let v = s.vol(100.0).unwrap().0;
+        let v = s.vol(Strike(100.0)).unwrap().0;
         assert!(v > 0.0, "beta=1 clamped vol must be positive");
         assert!(v < 0.01, "beta=1 clamped vol should be near-zero, got {v}");
     }
@@ -1206,9 +1211,9 @@ mod tests {
     fn vol_general_approaches_atm() {
         // As K → F from both sides, general formula should approach ATM formula
         let s = make_equity_smile();
-        let v_atm = s.vol(F).unwrap().0;
+        let v_atm = s.vol(Strike(F)).unwrap().0;
         for &eps in &[1e-3, 1e-4, 1e-5, 1e-6] {
-            let v = s.vol(F + eps).unwrap().0;
+            let v = s.vol(Strike(F + eps)).unwrap().0;
             let diff = (v - v_atm).abs();
             assert!(
                 diff < eps * 10.0, // vol difference should be proportional to eps
@@ -1237,7 +1242,7 @@ mod tests {
             1.0 + T * (0.25 * rho * nu * alpha + (2.0 - 3.0 * rho * rho) / 24.0 * nu * nu);
         let expected = alpha * z_ratio * correction;
 
-        let actual = s.vol(k).unwrap().0;
+        let actual = s.vol(Strike(k)).unwrap().0;
         let rel_err = (actual - expected).abs() / expected;
         assert!(
             rel_err < 1e-12,
@@ -1270,7 +1275,7 @@ mod tests {
                 + (2.0 - 3.0 * RHO * RHO) / 24.0 * NU * NU);
         let expected = (EQ_ALPHA / denom) * z_ratio * correction;
 
-        let actual = s.vol(k).unwrap().0;
+        let actual = s.vol(Strike(k)).unwrap().0;
         let rel_err = (actual - expected).abs() / expected;
         assert!(
             rel_err < 1e-14,
@@ -1283,7 +1288,7 @@ mod tests {
         let s = make_equity_smile();
         let strikes = [60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0, 140.0];
         for &k in &strikes {
-            let v = s.vol(k).unwrap().0;
+            let v = s.vol(Strike(k)).unwrap().0;
             assert!(
                 v > 0.01 && v < 2.0,
                 "Vol at K={k} should be reasonable, got {v}"
@@ -1295,8 +1300,8 @@ mod tests {
     fn vol_deep_otm_positive() {
         // Deep OTM strikes should still give positive vol (for reasonable params)
         let s = make_equity_smile();
-        assert!(s.vol(50.0).unwrap().0 > 0.0);
-        assert!(s.vol(200.0).unwrap().0 > 0.0);
+        assert!(s.vol(Strike(50.0)).unwrap().0 > 0.0);
+        assert!(s.vol(Strike(200.0)).unwrap().0 > 0.0);
     }
 
     // ========================================================================
@@ -1307,7 +1312,7 @@ mod tests {
     fn density_positive_for_typical_params() {
         let s = make_equity_smile();
         for &k in &[80.0, 90.0, 95.0, 100.0, 105.0, 110.0, 120.0] {
-            let d = s.density(k).unwrap();
+            let d = s.density(Strike(k)).unwrap();
             assert!(d > 0.0, "density should be positive at K={k}, got {d}");
         }
     }
@@ -1325,7 +1330,7 @@ mod tests {
         for i in 0..=n {
             let k = k_min + i as f64 * dk;
             let strike = s.forward() * k.exp();
-            let q = s.density(strike).unwrap();
+            let q = s.density(Strike(strike)).unwrap();
             let weight = if i == 0 || i == n { 0.5 } else { 1.0 };
             // Change of variable: dK = K dk
             integral += weight * q * strike * dk;
@@ -1340,9 +1345,9 @@ mod tests {
     fn density_peaks_near_forward() {
         // The density peak should be near the forward price
         let s = make_equity_smile();
-        let d_atm = s.density(F).unwrap();
-        let d_far_otm = s.density(200.0).unwrap();
-        let d_far_itm = s.density(50.0).unwrap();
+        let d_atm = s.density(Strike(F)).unwrap();
+        let d_far_otm = s.density(Strike(200.0)).unwrap();
+        let d_far_itm = s.density(Strike(50.0)).unwrap();
         assert!(
             d_atm > d_far_otm,
             "density at ATM ({d_atm}) should exceed far OTM ({d_far_otm})"
@@ -1357,8 +1362,8 @@ mod tests {
     fn variance_equals_vol_squared_times_t() {
         let s = make_equity_smile();
         for &k in &[80.0, 100.0, 120.0] {
-            let v = s.vol(k).unwrap().0;
-            let var = s.variance(k).unwrap().0;
+            let v = s.vol(Strike(k)).unwrap().0;
+            let var = s.variance(Strike(k)).unwrap().0;
             let expected = v * v * T;
             assert!(
                 (var - expected).abs() < 1e-14,
@@ -1451,7 +1456,7 @@ mod tests {
     fn sabr_as_trait_object() {
         let s = make_equity_smile();
         let boxed: Box<dyn SmileSection> = Box::new(s);
-        let v = boxed.vol(F).unwrap();
+        let v = boxed.vol(Strike(F)).unwrap();
         assert!(v.0 > 0.0);
         let report = boxed.is_arbitrage_free().unwrap();
         assert!(report.is_free);
@@ -1465,7 +1470,7 @@ mod tests {
     fn sabr_synthetic_data(smile: &SabrSmile, strikes: &[f64]) -> Vec<(f64, f64)> {
         strikes
             .iter()
-            .map(|&k| (k, smile.vol(k).unwrap().0))
+            .map(|&k| (k, smile.vol(Strike(k)).unwrap().0))
             .collect()
     }
 
@@ -1473,8 +1478,8 @@ mod tests {
     fn vol_rms(original: &SabrSmile, calibrated: &SabrSmile, strikes: &[f64]) -> f64 {
         let mut sum_sq = 0.0;
         for &k in strikes {
-            let v_orig = original.vol(k).unwrap().0;
-            let v_cal = calibrated.vol(k).unwrap().0;
+            let v_orig = original.vol(Strike(k)).unwrap().0;
+            let v_cal = calibrated.vol(Strike(k)).unwrap().0;
             sum_sq += (v_orig - v_cal).powi(2);
         }
         (sum_sq / strikes.len() as f64).sqrt()
@@ -1765,7 +1770,7 @@ mod tests {
     fn hagan_equity_k60() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 60.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(60.0).unwrap().0;
+        let actual = s.vol(Strike(60.0)).unwrap().0;
         let eps = expected * 1e-12;
         assert!(
             (actual - expected).abs() < eps,
@@ -1779,7 +1784,7 @@ mod tests {
     fn hagan_equity_k70() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 70.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(70.0).unwrap().0;
+        let actual = s.vol(Strike(70.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=70: expected {expected:.15e}, got {actual:.15e}"
@@ -1791,7 +1796,7 @@ mod tests {
     fn hagan_equity_k80() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 80.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(80.0).unwrap().0;
+        let actual = s.vol(Strike(80.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=80: expected {expected:.15e}, got {actual:.15e}"
@@ -1803,7 +1808,7 @@ mod tests {
     fn hagan_equity_k90() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 90.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(90.0).unwrap().0;
+        let actual = s.vol(Strike(90.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=90: expected {expected:.15e}, got {actual:.15e}"
@@ -1815,7 +1820,7 @@ mod tests {
     fn hagan_equity_k95() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 95.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(95.0).unwrap().0;
+        let actual = s.vol(Strike(95.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=95: expected {expected:.15e}, got {actual:.15e}"
@@ -1836,7 +1841,7 @@ mod tests {
                     * (omb * omb / 24.0 * 4.0 / (f_omb * f_omb)
                         + 0.25 * (-0.3) * 0.5 * 0.4 * 2.0 / f_omb
                         + (2.0 - 3.0 * 0.09) / 24.0 * 0.16));
-        let actual = s.vol(100.0).unwrap().0;
+        let actual = s.vol(Strike(100.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "ATM: expected {expected:.15e}, got {actual:.15e}"
@@ -1848,7 +1853,7 @@ mod tests {
     fn hagan_equity_k105() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 105.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(105.0).unwrap().0;
+        let actual = s.vol(Strike(105.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=105: expected {expected:.15e}, got {actual:.15e}"
@@ -1860,7 +1865,7 @@ mod tests {
     fn hagan_equity_k110() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 110.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(110.0).unwrap().0;
+        let actual = s.vol(Strike(110.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=110: expected {expected:.15e}, got {actual:.15e}"
@@ -1872,7 +1877,7 @@ mod tests {
     fn hagan_equity_k120() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 120.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(120.0).unwrap().0;
+        let actual = s.vol(Strike(120.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=120: expected {expected:.15e}, got {actual:.15e}"
@@ -1884,7 +1889,7 @@ mod tests {
     fn hagan_equity_k130() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 130.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(130.0).unwrap().0;
+        let actual = s.vol(Strike(130.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=130: expected {expected:.15e}, got {actual:.15e}"
@@ -1896,7 +1901,7 @@ mod tests {
     fn hagan_equity_k140() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
         let expected = hagan_reference(100.0, 140.0, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual = s.vol(140.0).unwrap().0;
+        let actual = s.vol(Strike(140.0)).unwrap().0;
         assert!(
             (actual - expected).abs() < expected * 1e-12,
             "K=140: expected {expected:.15e}, got {actual:.15e}"
@@ -1918,7 +1923,7 @@ mod tests {
 
         for &k in &[0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09] {
             let expected = hagan_reference(f, k, t, alpha, 0.0, rho, nu);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             let eps = expected.abs() * 1e-12;
             assert!(
                 (actual - expected).abs() < eps.max(1e-15),
@@ -1943,7 +1948,7 @@ mod tests {
 
         for &k in &[60.0, 80.0, 90.0, 100.0, 110.0, 120.0, 140.0] {
             let expected = hagan_reference(f, k, t, alpha, 1.0, rho, nu);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             let eps = expected * 1e-12;
             assert!(
                 (actual - expected).abs() < eps,
@@ -1963,7 +1968,7 @@ mod tests {
         // Cross-validate against independent reference
         for &k in &[80.0, 90.0, 100.0, 110.0, 120.0] {
             let expected = hagan_reference(100.0, k, 1.0, 2.0, 0.5, -0.3, nu_tiny);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             let eps = expected * 1e-12;
             assert!(
                 (actual - expected).abs() < eps.max(1e-15),
@@ -1979,7 +1984,7 @@ mod tests {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.0).unwrap();
         for &k in &[80.0, 100.0, 120.0] {
             let expected = hagan_reference(100.0, k, 1.0, 2.0, 0.5, -0.3, 0.0);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             assert!(
                 (actual - expected).abs() < expected * 1e-12,
                 "ν=0, K={k}: expected {expected:.15e}, got {actual:.15e}"
@@ -1995,7 +2000,7 @@ mod tests {
         let s = SabrSmile::new(100.0, t, 2.0, 0.5, -0.3, 0.4).unwrap();
         for &k in &[90.0, 95.0, 100.0, 105.0, 110.0] {
             let expected = hagan_reference(100.0, k, t, 2.0, 0.5, -0.3, 0.4);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             let eps = expected * 1e-12;
             assert!(
                 (actual - expected).abs() < eps,
@@ -2012,7 +2017,7 @@ mod tests {
         let s = SabrSmile::new(100.0, t, 2.0, 0.5, -0.3, 0.4).unwrap();
         for &k in &[70.0, 85.0, 100.0, 115.0, 130.0] {
             let expected = hagan_reference(100.0, k, t, 2.0, 0.5, -0.3, 0.4);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             let eps = expected * 1e-12;
             assert!(
                 (actual - expected).abs() < eps,
@@ -2027,12 +2032,12 @@ mod tests {
     #[test]
     fn hagan_atm_continuity_approach() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.3, 0.4).unwrap();
-        let vol_atm = s.vol(100.0).unwrap().0;
+        let vol_atm = s.vol(Strike(100.0)).unwrap().0;
 
         // Approach from below and above
         for &delta in &[1e-3, 1e-5, 1e-7, 1e-9] {
-            let v_below = s.vol(100.0 - delta).unwrap().0;
-            let v_above = s.vol(100.0 + delta).unwrap().0;
+            let v_below = s.vol(Strike(100.0 - delta)).unwrap().0;
+            let v_above = s.vol(Strike(100.0 + delta)).unwrap().0;
             assert!(
                 (v_below - vol_atm).abs() < delta * 0.1,
                 "δ={delta}: vol(F-δ)={v_below} should approach vol(F)={vol_atm}"
@@ -2053,7 +2058,7 @@ mod tests {
         // Deep OTM put
         let k_low = 10.0; // K/F = 0.1
         let expected_low = hagan_reference(100.0, k_low, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual_low = s.vol(k_low).unwrap().0;
+        let actual_low = s.vol(Strike(k_low)).unwrap().0;
         assert!(
             (actual_low - expected_low).abs() < expected_low * 1e-12,
             "K=10: expected {expected_low:.15e}, got {actual_low:.15e}"
@@ -2062,7 +2067,7 @@ mod tests {
         // Deep OTM call
         let k_high = 500.0; // K/F = 5
         let expected_high = hagan_reference(100.0, k_high, 1.0, 2.0, 0.5, -0.3, 0.4);
-        let actual_high = s.vol(k_high).unwrap().0;
+        let actual_high = s.vol(Strike(k_high)).unwrap().0;
         assert!(
             (actual_high - expected_high).abs() < expected_high * 1e-12,
             "K=500: expected {expected_high:.15e}, got {actual_high:.15e}"
@@ -2082,7 +2087,7 @@ mod tests {
 
         for &k in &[35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0] {
             let expected = hagan_reference(f, k, t, alpha, 0.5, rho, nu);
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             let eps = expected * 1e-12;
             assert!(
                 (actual - expected).abs() < eps,
@@ -2106,7 +2111,7 @@ mod tests {
         let offsets = [-1e-5, -1e-6, -1e-7, 0.0, 1e-7, 1e-6, 1e-5];
         let vols: Vec<f64> = offsets
             .iter()
-            .map(|&dk| s.vol(k_base + dk).unwrap().0)
+            .map(|&dk| s.vol(Strike(k_base + dk)).unwrap().0)
             .collect();
 
         // All vols should be within 1e-10 of each other (smooth transition)
@@ -2127,9 +2132,9 @@ mod tests {
     #[test]
     fn hagan_skew_direction_negative_rho() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, -0.5, 0.4).unwrap();
-        let v_low = s.vol(80.0).unwrap().0;
-        let v_atm = s.vol(100.0).unwrap().0;
-        let v_high = s.vol(120.0).unwrap().0;
+        let v_low = s.vol(Strike(80.0)).unwrap().0;
+        let v_atm = s.vol(Strike(100.0)).unwrap().0;
+        let v_high = s.vol(Strike(120.0)).unwrap().0;
         assert!(
             v_low > v_atm,
             "ρ<0: vol(K<F)={v_low} should > vol(ATM)={v_atm}"
@@ -2144,8 +2149,8 @@ mod tests {
     #[test]
     fn hagan_skew_direction_positive_rho() {
         let s = SabrSmile::new(100.0, 1.0, 2.0, 0.5, 0.5, 0.4).unwrap();
-        let v_low = s.vol(80.0).unwrap().0;
-        let v_high = s.vol(120.0).unwrap().0;
+        let v_low = s.vol(Strike(80.0)).unwrap().0;
+        let v_high = s.vol(Strike(120.0)).unwrap().0;
         // Positive rho: OTM calls have higher vol than OTM puts (reversed skew)
         assert!(
             v_high > v_low,
@@ -2178,7 +2183,7 @@ mod tests {
         // RMS against noisy data (fitted noise is absorbed)
         let rms: f64 = (noisy_data
             .iter()
-            .map(|&(k, v)| (calibrated.vol(k).unwrap().0 - v).powi(2))
+            .map(|&(k, v)| (calibrated.vol(Strike(k)).unwrap().0 - v).powi(2))
             .sum::<f64>()
             / noisy_data.len() as f64)
             .sqrt();
@@ -2208,7 +2213,7 @@ mod tests {
         let calibrated = SabrSmile::calibrate(100.0, 1.0, 1.0, &noisy_data).unwrap();
         let rms: f64 = (noisy_data
             .iter()
-            .map(|&(k, v)| (calibrated.vol(k).unwrap().0 - v).powi(2))
+            .map(|&(k, v)| (calibrated.vol(Strike(k)).unwrap().0 - v).powi(2))
             .sum::<f64>()
             / noisy_data.len() as f64)
             .sqrt();
@@ -2225,7 +2230,7 @@ mod tests {
         let alpha = 0.25;
         let s = SabrSmile::new(100.0, 1.0, alpha, 1.0, 0.0, 0.0).unwrap();
         for &k in &[50.0, 75.0, 100.0, 125.0, 150.0] {
-            let actual = s.vol(k).unwrap().0;
+            let actual = s.vol(Strike(k)).unwrap().0;
             assert!(
                 (actual - alpha).abs() < 1e-10,
                 "Pure lognormal K={k}: expected α={alpha}, got {actual}"
@@ -2241,7 +2246,7 @@ mod tests {
         let beta = 0.5;
         let s = SabrSmile::new(100.0, 1.0, alpha, beta, 0.0, 0.0).unwrap();
         let expected_atm = alpha / 100.0_f64.powf(1.0 - beta);
-        let actual = s.vol(100.0).unwrap().0;
+        let actual = s.vol(Strike(100.0)).unwrap().0;
         // Only correction term is (1-β)²/24 * α²/F^(2(1-β))
         let correction = 1.0 + 0.25 / 24.0 * alpha * alpha / (100.0_f64.powf(1.0 - beta)).powi(2);
         let expected_corrected = expected_atm * correction;

--- a/src/smile/sabr.rs
+++ b/src/smile/sabr.rs
@@ -1043,6 +1043,19 @@ mod tests {
     }
 
     #[test]
+    fn vol_rejects_inf_strike() {
+        let s = make_equity_smile();
+        assert!(matches!(
+            s.vol(Strike(f64::INFINITY)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            s.vol(Strike(f64::NEG_INFINITY)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
     fn vol_variance_consistency() {
         // variance() = vol()² * T (from SmileSection default impl)
         let s = make_equity_smile();

--- a/src/smile/spline.rs
+++ b/src/smile/spline.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{self, VolSurfError};
 use crate::smile::SmileSection;
 use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
-use crate::types::{Variance, Vol};
+use crate::types::{Strike, Variance, Vol};
 use crate::validate::validate_positive;
 
 /// Coefficients for one cubic polynomial interval.
@@ -246,9 +246,9 @@ fn build_spline_coefficients(x: &[f64], y: &[f64], n: usize) -> Vec<SplineCoeff>
 }
 
 impl SmileSection for SplineSmile {
-    fn vol(&self, strike: f64) -> error::Result<Vol> {
-        validate_positive(strike, "strike")?;
-        let w = self.eval_variance(strike);
+    fn vol(&self, strike: Strike) -> error::Result<Vol> {
+        validate_positive(strike.0, "strike")?;
+        let w = self.eval_variance(strike.0);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
                 message: format!("negative interpolated variance {w} at strike {strike}"),
@@ -257,9 +257,9 @@ impl SmileSection for SplineSmile {
         Ok(Vol((w / self.expiry).sqrt()))
     }
 
-    fn variance(&self, strike: f64) -> error::Result<Variance> {
-        validate_positive(strike, "strike")?;
-        let w = self.eval_variance(strike);
+    fn variance(&self, strike: Strike) -> error::Result<Variance> {
+        validate_positive(strike.0, "strike")?;
+        let w = self.eval_variance(strike.0);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
                 message: format!("negative interpolated variance {w} at strike {strike}"),
@@ -286,7 +286,7 @@ impl SmileSection for SplineSmile {
         let mut violations = Vec::new();
         for i in 1..n_samples {
             let k = k_min + dk * (i as f64);
-            let d = self.density(k)?;
+            let d = self.density(Strike(k))?;
             // Tolerance for negative density detection.
             if d < -1e-8 {
                 violations.push(ButterflyViolation {
@@ -307,6 +307,7 @@ impl SmileSection for SplineSmile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Strike;
     use approx::assert_abs_diff_eq;
 
     /// Flat 20% vol smile for validation tests.
@@ -410,7 +411,7 @@ mod tests {
         let smile = SplineSmile::new(100.0, expiry, strikes.clone(), variances.clone()).unwrap();
 
         for (k, w) in strikes.iter().zip(variances.iter()) {
-            let vol = smile.vol(*k).unwrap();
+            let vol = smile.vol(Strike(*k)).unwrap();
             let expected = (*w / expiry).sqrt();
             assert_abs_diff_eq!(vol.0, expected, epsilon = 1e-14);
         }
@@ -423,7 +424,7 @@ mod tests {
         let smile = SplineSmile::new(100.0, 1.0, strikes.clone(), variances.clone()).unwrap();
 
         for (k, w) in strikes.iter().zip(variances.iter()) {
-            let var = smile.variance(*k).unwrap();
+            let var = smile.variance(Strike(*k)).unwrap();
             assert_abs_diff_eq!(var.0, *w, epsilon = 1e-14);
         }
     }
@@ -438,7 +439,7 @@ mod tests {
 
         let expected_vol = w.sqrt();
         for k in [75.0, 85.0, 95.0, 100.0, 105.0, 115.0, 125.0] {
-            let vol = smile.vol(k).unwrap();
+            let vol = smile.vol(Strike(k)).unwrap();
             assert_abs_diff_eq!(vol.0, expected_vol, epsilon = 1e-14);
         }
     }
@@ -452,8 +453,8 @@ mod tests {
         let smile = SplineSmile::new(100.0, expiry, strikes, variances).unwrap();
 
         for k in [82.0, 95.0, 105.0, 118.0] {
-            let vol = smile.vol(k).unwrap();
-            let var = smile.variance(k).unwrap();
+            let vol = smile.vol(Strike(k)).unwrap();
+            let var = smile.variance(Strike(k)).unwrap();
             assert_abs_diff_eq!(var.0, vol.0 * vol.0 * expiry, epsilon = 1e-14);
         }
     }
@@ -464,7 +465,7 @@ mod tests {
         let variances = vec![0.065, 0.045, 0.04, 0.045, 0.065];
         let smile = SplineSmile::new(100.0, 1.0, strikes, variances).unwrap();
 
-        let var_below = smile.variance(50.0).unwrap();
+        let var_below = smile.variance(Strike(50.0)).unwrap();
         assert_abs_diff_eq!(var_below.0, 0.065, epsilon = 1e-14);
     }
 
@@ -474,7 +475,7 @@ mod tests {
         let variances = vec![0.065, 0.045, 0.04, 0.045, 0.065];
         let smile = SplineSmile::new(100.0, 1.0, strikes, variances).unwrap();
 
-        let var_above = smile.variance(200.0).unwrap();
+        let var_above = smile.variance(Strike(200.0)).unwrap();
         assert_abs_diff_eq!(var_above.0, 0.065, epsilon = 1e-14);
     }
 
@@ -485,7 +486,7 @@ mod tests {
         let smile = SplineSmile::new(100.0, 1.0, strikes, variances).unwrap();
 
         for k in [0.01, 1.0, 50.0, 500.0, 10000.0] {
-            let vol = smile.vol(k).unwrap();
+            let vol = smile.vol(Strike(k)).unwrap();
             assert!(vol.0.is_finite(), "vol at K={k} should be finite");
         }
     }
@@ -537,7 +538,7 @@ mod tests {
         let smile = SplineSmile::new(100.0, 1.0, strikes, variances).unwrap();
 
         for k in [85.0, 90.0, 95.0, 100.0, 105.0, 110.0, 115.0] {
-            let d = smile.density(k).unwrap();
+            let d = smile.density(Strike(k)).unwrap();
             assert!(
                 d >= -1e-8,
                 "density at K={k} should be non-negative, got {d}"
@@ -559,7 +560,7 @@ mod tests {
         let mut integral = 0.0;
         for i in 0..n {
             let k = k_lo + dk * (i as f64 + 0.5);
-            integral += smile.density(k).unwrap() * dk;
+            integral += smile.density(Strike(k)).unwrap() * dk;
         }
         // Tolerance is generous: finite integration range + numerical density
         assert_abs_diff_eq!(integral, 1.0, epsilon = 0.10);
@@ -608,7 +609,7 @@ mod tests {
     fn zero_variance_produces_zero_vol() {
         let smile =
             SplineSmile::new(100.0, 1.0, vec![80.0, 100.0, 120.0], vec![0.04, 0.0, 0.04]).unwrap();
-        let vol = smile.vol(100.0).unwrap();
+        let vol = smile.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.0, epsilon = 1e-14);
     }
 
@@ -622,10 +623,10 @@ mod tests {
         let smile = SplineSmile::new(100.0, 1.0, strikes, variances).unwrap();
 
         // Check that vol changes smoothly between knots
-        let mut prev_vol = smile.vol(80.0).unwrap().0;
+        let mut prev_vol = smile.vol(Strike(80.0)).unwrap().0;
         for i in 1..=40 {
             let k = 80.0 + i as f64;
-            let vol = smile.vol(k).unwrap().0;
+            let vol = smile.vol(Strike(k)).unwrap().0;
             let change = (vol - prev_vol).abs();
             assert!(
                 change < 0.05,
@@ -641,7 +642,7 @@ mod tests {
     fn vol_rejects_nan_strike() {
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.vol(f64::NAN),
+            smile.vol(Strike(f64::NAN)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -650,7 +651,7 @@ mod tests {
     fn vol_rejects_negative_strike() {
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.vol(-1.0),
+            smile.vol(Strike(-1.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -659,7 +660,7 @@ mod tests {
     fn vol_rejects_zero_strike() {
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.vol(0.0),
+            smile.vol(Strike(0.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -668,7 +669,7 @@ mod tests {
     fn variance_rejects_nan_strike() {
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.variance(f64::NAN),
+            smile.variance(Strike(f64::NAN)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -677,7 +678,7 @@ mod tests {
     fn variance_rejects_zero_strike() {
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.variance(0.0),
+            smile.variance(Strike(0.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -709,7 +710,7 @@ mod tests {
         let mut found_negative = false;
         for i in 0..400 {
             let strike = 1.01 + i as f64 * 0.01;
-            if let Err(VolSurfError::NumericalError { .. }) = smile.vol(strike) {
+            if let Err(VolSurfError::NumericalError { .. }) = smile.vol(Strike(strike)) {
                 found_negative = true;
                 break;
             }
@@ -726,7 +727,7 @@ mod tests {
         let mut found_negative = false;
         for i in 0..400 {
             let strike = 1.01 + i as f64 * 0.01;
-            if let Err(VolSurfError::NumericalError { .. }) = smile.variance(strike) {
+            if let Err(VolSurfError::NumericalError { .. }) = smile.variance(Strike(strike)) {
                 found_negative = true;
                 break;
             }
@@ -750,7 +751,7 @@ mod tests {
         let mut error_strike = None;
         for i in 0..400 {
             let strike = 1.01 + i as f64 * 0.01;
-            if smile.vol(strike).is_err() {
+            if smile.vol(Strike(strike)).is_err() {
                 error_strike = Some(strike);
                 break;
             }
@@ -758,7 +759,7 @@ mod tests {
         let strike = error_strike.expect("should find a failing strike");
 
         // density() should propagate the error from vol()
-        let density_result = smile.density(strike);
+        let density_result = smile.density(Strike(strike));
         assert!(
             density_result.is_err(),
             "density() should propagate vol() error at K={strike}"
@@ -770,7 +771,7 @@ mod tests {
         // Default density() validates strike > 0 before calling vol()
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.density(0.0),
+            smile.density(Strike(0.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -779,7 +780,7 @@ mod tests {
     fn default_density_rejects_negative_strike() {
         let smile = make_flat_smile();
         assert!(matches!(
-            smile.density(-10.0),
+            smile.density(Strike(-10.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -795,8 +796,8 @@ mod tests {
         );
         assert_eq!(SmileSection::expiry(&smile), SmileSection::expiry(&smile2));
         for &k in &[80.0, 90.0, 100.0, 110.0, 120.0] {
-            let v1 = smile.vol(k).unwrap();
-            let v2 = smile2.vol(k).unwrap();
+            let v1 = smile.vol(Strike(k)).unwrap();
+            let v2 = smile2.vol(Strike(k)).unwrap();
             assert!((v1.0 - v2.0).abs() < 1e-15, "vol mismatch at strike {k}");
         }
     }

--- a/src/smile/spline.rs
+++ b/src/smile/spline.rs
@@ -648,6 +648,19 @@ mod tests {
     }
 
     #[test]
+    fn vol_rejects_inf_strike() {
+        let smile = make_flat_smile();
+        assert!(matches!(
+            smile.vol(Strike(f64::INFINITY)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            smile.vol(Strike(f64::NEG_INFINITY)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
     fn vol_rejects_negative_strike() {
         let smile = make_flat_smile();
         assert!(matches!(

--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -884,6 +884,28 @@ mod tests {
     }
 
     #[test]
+    fn vol_rejects_nan_strike() {
+        let smile = make_smile();
+        assert!(matches!(
+            smile.vol(Strike(f64::NAN)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
+    fn vol_rejects_inf_strike() {
+        let smile = make_smile();
+        assert!(matches!(
+            smile.vol(Strike(f64::INFINITY)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            smile.vol(Strike(f64::NEG_INFINITY)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
     fn variance_consistent_with_vol() {
         let smile = make_smile();
         let vol = smile.vol(Strike(100.0)).unwrap();
@@ -973,6 +995,24 @@ mod tests {
         let smile = make_arb_free_smile();
         assert!(matches!(
             smile.density(Strike(0.0)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
+    fn density_rejects_nan_strike() {
+        let smile = make_arb_free_smile();
+        assert!(matches!(
+            smile.density(Strike(f64::NAN)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
+    fn density_rejects_inf_strike() {
+        let smile = make_arb_free_smile();
+        assert!(matches!(
+            smile.density(Strike(f64::INFINITY)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }

--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -22,7 +22,7 @@ use nalgebra::{DMatrix, DVector};
 use crate::error::{self, VolSurfError};
 use crate::smile::SmileSection;
 use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
-use crate::types::Vol;
+use crate::types::{Strike, Vol};
 use crate::validate::validate_positive;
 
 /// SVI volatility smile with 5 parameters.
@@ -576,9 +576,9 @@ impl SviSmile {
 }
 
 impl SmileSection for SviSmile {
-    fn vol(&self, strike: f64) -> error::Result<Vol> {
-        validate_positive(strike, "strike")?;
-        let k = (strike / self.forward).ln();
+    fn vol(&self, strike: Strike) -> error::Result<Vol> {
+        validate_positive(strike.0, "strike")?;
+        let k = (strike.0 / self.forward).ln();
         let w = self.total_variance_at_k(k);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -599,9 +599,9 @@ impl SmileSection for SviSmile {
     ///
     /// # Reference
     /// Breeden & Litzenberger (1978); Gatheral & Jacquier (2014), §4.
-    fn density(&self, strike: f64) -> error::Result<f64> {
-        validate_positive(strike, "strike")?;
-        let k = (strike / self.forward).ln();
+    fn density(&self, strike: Strike) -> error::Result<f64> {
+        validate_positive(strike.0, "strike")?;
+        let k = (strike.0 / self.forward).ln();
         let w = self.total_variance_at_k(k);
         if w <= 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -612,7 +612,7 @@ impl SmileSection for SviSmile {
         let sqrt_w = w.sqrt();
         let d2 = -k / sqrt_w - sqrt_w / 2.0;
         let n_d2 = (-d2 * d2 / 2.0).exp() / (2.0 * PI).sqrt();
-        Ok(g * n_d2 / (strike * sqrt_w))
+        Ok(g * n_d2 / (strike.0 * sqrt_w))
     }
 
     fn forward(&self) -> f64 {
@@ -645,7 +645,7 @@ impl SmileSection for SviSmile {
             let g = self.g_function(k);
             if g < -super::BUTTERFLY_G_TOL {
                 let strike = self.forward * k.exp();
-                let d = match self.density(strike) {
+                let d = match self.density(Strike(strike)) {
                     Ok(d) => d,
                     Err(_) => continue,
                 };
@@ -799,7 +799,7 @@ mod tests {
     #[test]
     fn vol_atm() {
         let smile = make_smile();
-        let vol = smile.vol(F).unwrap();
+        let vol = smile.vol(Strike(F)).unwrap();
         // ATM (k=0, m=0): w = a + b*(rho*0 + sqrt(0 + sigma^2)) = a + b*sigma
         // w = 0.04 + 0.4*0.1 = 0.08, vol = sqrt(0.08/1.0) = 0.28284...
         let expected_w = A + B * SIGMA;
@@ -815,7 +815,7 @@ mod tests {
         let dk = k - M;
         let expected_w = A + B * (RHO * dk + (dk * dk + SIGMA * SIGMA).sqrt());
         let expected_vol = (expected_w / T).sqrt();
-        let vol = smile.vol(80.0).unwrap();
+        let vol = smile.vol(Strike(80.0)).unwrap();
         assert_abs_diff_eq!(vol.0, expected_vol, epsilon = 1e-14);
     }
 
@@ -827,7 +827,7 @@ mod tests {
         let dk = k - M;
         let expected_w = A + B * (RHO * dk + (dk * dk + SIGMA * SIGMA).sqrt());
         let expected_vol = (expected_w / T).sqrt();
-        let vol = smile.vol(120.0).unwrap();
+        let vol = smile.vol(Strike(120.0)).unwrap();
         assert_abs_diff_eq!(vol.0, expected_vol, epsilon = 1e-14);
     }
 
@@ -838,8 +838,8 @@ mod tests {
         let strikes = [80.0, 90.0, 95.0, 98.0];
         for &k in &strikes {
             let mirror = F * F / k; // mirror strike
-            let v1 = smile.vol(k).unwrap();
-            let v2 = smile.vol(mirror).unwrap();
+            let v1 = smile.vol(Strike(k)).unwrap();
+            let v2 = smile.vol(Strike(mirror)).unwrap();
             assert_abs_diff_eq!(v1.0, v2.0, epsilon = 1e-14);
         }
     }
@@ -847,8 +847,8 @@ mod tests {
     #[test]
     fn skew_negative_rho() {
         let smile = make_smile(); // rho = -0.4
-        let vol_low = smile.vol(80.0).unwrap();
-        let vol_high = smile.vol(120.0).unwrap();
+        let vol_low = smile.vol(Strike(80.0)).unwrap();
+        let vol_high = smile.vol(Strike(120.0)).unwrap();
         assert!(
             vol_low.0 > vol_high.0,
             "negative rho should produce higher vol for lower strikes: \
@@ -861,8 +861,8 @@ mod tests {
     #[test]
     fn skew_positive_rho() {
         let smile = SviSmile::new(F, T, A, B, 0.4, M, SIGMA).unwrap();
-        let vol_low = smile.vol(80.0).unwrap();
-        let vol_high = smile.vol(120.0).unwrap();
+        let vol_low = smile.vol(Strike(80.0)).unwrap();
+        let vol_high = smile.vol(Strike(120.0)).unwrap();
         assert!(
             vol_high.0 > vol_low.0,
             "positive rho should produce higher vol for higher strikes"
@@ -872,22 +872,22 @@ mod tests {
     #[test]
     fn vol_rejects_zero_strike() {
         let smile = make_smile();
-        let r = smile.vol(0.0);
+        let r = smile.vol(Strike(0.0));
         assert!(matches!(r, Err(VolSurfError::InvalidInput { .. })));
     }
 
     #[test]
     fn vol_rejects_negative_strike() {
         let smile = make_smile();
-        let r = smile.vol(-10.0);
+        let r = smile.vol(Strike(-10.0));
         assert!(matches!(r, Err(VolSurfError::InvalidInput { .. })));
     }
 
     #[test]
     fn variance_consistent_with_vol() {
         let smile = make_smile();
-        let vol = smile.vol(100.0).unwrap();
-        let var = smile.variance(100.0).unwrap();
+        let vol = smile.vol(Strike(100.0)).unwrap();
+        let var = smile.variance(Strike(100.0)).unwrap();
         // variance = vol^2 * T
         assert_abs_diff_eq!(var.0, vol.0 * vol.0 * T, epsilon = 1e-14);
     }
@@ -895,9 +895,9 @@ mod tests {
     #[test]
     fn flat_smile_with_zero_b() {
         let smile = SviSmile::new(F, T, 0.04, 0.0, 0.0, 0.0, 0.1).unwrap();
-        let vol_80 = smile.vol(80.0).unwrap();
-        let vol_100 = smile.vol(100.0).unwrap();
-        let vol_120 = smile.vol(120.0).unwrap();
+        let vol_80 = smile.vol(Strike(80.0)).unwrap();
+        let vol_100 = smile.vol(Strike(100.0)).unwrap();
+        let vol_120 = smile.vol(Strike(120.0)).unwrap();
         // b=0 => w(k) = a for all k => vol = sqrt(a/T)
         let expected = (0.04_f64 / T).sqrt();
         assert_abs_diff_eq!(vol_80.0, expected, epsilon = 1e-14);
@@ -920,7 +920,7 @@ mod tests {
     #[test]
     fn density_atm_positive() {
         let smile = make_arb_free_smile();
-        let d = smile.density(100.0).unwrap();
+        let d = smile.density(Strike(100.0)).unwrap();
         assert!(d > 0.0, "ATM density should be positive, got {d}");
     }
 
@@ -931,7 +931,7 @@ mod tests {
             .map(|i| 100.0 * ((-3.0 + 6.0 * i as f64 / 200.0).exp()))
             .collect();
         for &k in &strikes {
-            let d = smile.density(k).unwrap();
+            let d = smile.density(Strike(k)).unwrap();
             assert!(
                 d >= -1e-15,
                 "density should be non-negative for arb-free params at K={k}, got {d}"
@@ -944,7 +944,7 @@ mod tests {
         // For symmetric arb-free SVI, density should be positive everywhere
         let smile = SviSmile::new(100.0, 1.0, 0.04, 0.4, 0.0, 0.0, 0.2).unwrap();
         for &strike in &[50.0, 80.0, 90.0, 100.0, 110.0, 120.0, 150.0] {
-            let d = smile.density(strike).unwrap();
+            let d = smile.density(Strike(strike)).unwrap();
             assert!(d > 0.0, "density should be positive at K={strike}, got {d}");
         }
     }
@@ -960,7 +960,7 @@ mod tests {
         for i in 0..=n {
             let k = k_min + i as f64 * dk;
             let strike = smile.forward() * k.exp();
-            let q = smile.density(strike).unwrap();
+            let q = smile.density(Strike(strike)).unwrap();
             let weight = if i == 0 || i == n { 0.5 } else { 1.0 };
             // q(K) dK = q(K) * K * dk  (change of variable: dK = K dk)
             integral += weight * q * strike * dk;
@@ -972,7 +972,7 @@ mod tests {
     fn density_rejects_zero_strike() {
         let smile = make_arb_free_smile();
         assert!(matches!(
-            smile.density(0.0),
+            smile.density(Strike(0.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -989,14 +989,14 @@ mod tests {
 
         for &strike in &[80.0, 100.0, 120.0] {
             let h = strike * 1e-4;
-            let vol_m = smile.vol(strike - h).unwrap().0;
-            let vol_0 = smile.vol(strike).unwrap().0;
-            let vol_p = smile.vol(strike + h).unwrap().0;
+            let vol_m = smile.vol(Strike(strike - h)).unwrap().0;
+            let vol_0 = smile.vol(Strike(strike)).unwrap().0;
+            let vol_p = smile.vol(Strike(strike + h)).unwrap().0;
             let c_m = black_price(f, strike - h, vol_m, t, OptionType::Call).unwrap();
             let c_0 = black_price(f, strike, vol_0, t, OptionType::Call).unwrap();
             let c_p = black_price(f, strike + h, vol_p, t, OptionType::Call).unwrap();
             let numerical = (c_p - 2.0 * c_0 + c_m) / (h * h);
-            let analytical = smile.density(strike).unwrap();
+            let analytical = smile.density(Strike(strike)).unwrap();
             assert_abs_diff_eq!(analytical, numerical, epsilon = 1e-4);
         }
     }
@@ -1032,7 +1032,7 @@ mod tests {
         let report = smile.is_arbitrage_free().unwrap();
         assert!(!report.butterfly_violations.is_empty());
         for v in &report.butterfly_violations {
-            let expected = smile.density(v.strike).unwrap();
+            let expected = smile.density(Strike(v.strike)).unwrap();
             assert_abs_diff_eq!(v.density, expected, epsilon = 1e-14);
             assert_abs_diff_eq!(v.magnitude, expected.abs(), epsilon = 1e-14);
         }
@@ -1068,7 +1068,7 @@ mod tests {
         (strikes
             .iter()
             .map(|&k| {
-                let diff = a.vol(k).unwrap().0 - b.vol(k).unwrap().0;
+                let diff = a.vol(Strike(k)).unwrap().0 - b.vol(Strike(k)).unwrap().0;
                 diff * diff
             })
             .sum::<f64>()
@@ -1080,7 +1080,7 @@ mod tests {
     fn synthetic_market_data(smile: &SviSmile, strikes: &[f64]) -> Vec<(f64, f64)> {
         strikes
             .iter()
-            .map(|&k| (k, smile.vol(k).unwrap().0))
+            .map(|&k| (k, smile.vol(Strike(k)).unwrap().0))
             .collect()
     }
 
@@ -1215,7 +1215,7 @@ mod tests {
         let rms = (data
             .iter()
             .map(|&(k, sigma)| {
-                let fitted = calibrated.vol(k).unwrap().0;
+                let fitted = calibrated.vol(Strike(k)).unwrap().0;
                 (fitted - sigma).powi(2)
             })
             .sum::<f64>()
@@ -1281,7 +1281,7 @@ mod tests {
     #[test]
     fn vol_returns_error_when_total_variance_is_negative() {
         let smile = make_invalid_svi();
-        let result = smile.vol(100.0);
+        let result = smile.vol(Strike(100.0));
         assert!(
             matches!(result, Err(VolSurfError::NumericalError { .. })),
             "vol() should return NumericalError for negative variance, got {result:?}"
@@ -1293,7 +1293,7 @@ mod tests {
     #[test]
     fn density_returns_error_when_total_variance_non_positive() {
         let smile = make_invalid_svi();
-        let result = smile.density(100.0);
+        let result = smile.density(Strike(100.0));
         assert!(
             matches!(result, Err(VolSurfError::NumericalError { .. })),
             "density() should return NumericalError for non-positive variance, got {result:?}"
@@ -1412,7 +1412,7 @@ mod tests {
         // (albeit imprecise) fit, or fail with Roger Lee / ATM sanity rejection.
         match SviSmile::calibrate(forward, expiry, &data) {
             Ok(smile) => {
-                let atm_vol = smile.vol(forward).unwrap().0;
+                let atm_vol = smile.vol(Strike(forward)).unwrap().0;
                 assert!(
                     atm_vol > 0.10 && atm_vol < 1.0,
                     "ATM vol {atm_vol:.4} outside [0.10, 1.0]"
@@ -1458,7 +1458,7 @@ mod tests {
         // fit rejected by Roger Lee bound or ATM sanity check.
         match SviSmile::calibrate(forward, expiry, &data) {
             Ok(smile) => {
-                let atm_vol = smile.vol(forward).unwrap().0;
+                let atm_vol = smile.vol(Strike(forward)).unwrap().0;
                 assert!(
                     atm_vol.is_finite() && atm_vol > 0.0,
                     "ATM vol should be finite and positive, got {atm_vol}"
@@ -1484,7 +1484,7 @@ mod tests {
         (data
             .iter()
             .map(|&(strike, vol_obs)| {
-                let vol_fit = smile.vol(strike).unwrap().0;
+                let vol_fit = smile.vol(Strike(strike)).unwrap().0;
                 (vol_fit - vol_obs).powi(2)
             })
             .sum::<f64>()
@@ -1664,7 +1664,7 @@ mod tests {
         let smile = SviSmile::calibrate(forward, expiry, &data)
             .expect("SPX both-sided calibration should succeed");
 
-        let atm_vol = smile.vol(forward).unwrap().0;
+        let atm_vol = smile.vol(Strike(forward)).unwrap().0;
         assert!(
             atm_vol > 0.10 && atm_vol < 0.25,
             "ATM vol {:.4} outside [10%, 25%] — calibration produced degenerate params",
@@ -1691,8 +1691,8 @@ mod tests {
         data[8].1 += 0.10;
 
         let calibrated = SviSmile::calibrate(100.0, 0.5, &data).unwrap();
-        let true_atm = true_smile.vol(100.0).unwrap().0;
-        let fit_atm = calibrated.vol(100.0).unwrap().0;
+        let true_atm = true_smile.vol(Strike(100.0)).unwrap().0;
+        let fit_atm = calibrated.vol(Strike(100.0)).unwrap().0;
         let atm_err = (fit_atm - true_atm).abs();
         assert!(
             atm_err < 0.02,
@@ -1711,7 +1711,7 @@ mod tests {
             .collect();
         match SviSmile::calibrate(forward, expiry, &data) {
             Ok(smile) => {
-                let vol = smile.vol(130.0).unwrap().0;
+                let vol = smile.vol(Strike(130.0)).unwrap().0;
                 assert!(vol.is_finite() && vol > 0.0);
             }
             Err(VolSurfError::CalibrationError { message, .. }) => {
@@ -1746,7 +1746,7 @@ mod tests {
         match SviSmile::calibrate(forward, expiry, &data) {
             Ok(smile) => {
                 // If it calibrates, ATM should still be reasonable (sanity check passed)
-                let atm = smile.vol(forward).unwrap().0;
+                let atm = smile.vol(Strike(forward)).unwrap().0;
                 assert!(
                     atm < 0.80,
                     "degenerate ATM {atm:.4} should be caught by sanity check"

--- a/src/surface/builder.rs
+++ b/src/surface/builder.rs
@@ -2,6 +2,7 @@
 //!
 //! ```
 //! use volsurf::surface::{SurfaceBuilder, VolSurface};
+//! use volsurf::types::{Strike, Tenor};
 //!
 //! let strikes = vec![80.0, 90.0, 95.0, 100.0, 105.0, 110.0, 120.0];
 //! let vols = vec![0.28, 0.24, 0.22, 0.20, 0.22, 0.24, 0.28];
@@ -14,7 +15,7 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! let vol = surface.black_vol(0.5, 100.0).unwrap();
+//! let vol = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
 //! assert!(vol.0 > 0.0);
 //! ```
 
@@ -97,6 +98,7 @@ impl TryFrom<SmileModelRaw> for SmileModel {
 ///
 /// ```
 /// use volsurf::surface::{SurfaceBuilder, SmileModel, VolSurface};
+/// use volsurf::types::{Strike, Tenor};
 ///
 /// let strikes = vec![80.0, 90.0, 95.0, 100.0, 105.0, 110.0, 120.0];
 /// let vols = vec![0.28, 0.24, 0.22, 0.20, 0.22, 0.24, 0.28];
@@ -109,7 +111,7 @@ impl TryFrom<SmileModelRaw> for SmileModel {
 ///     .add_tenor(1.00, &strikes, &vols)
 ///     .build()?;
 ///
-/// let vol = surface.black_vol(0.5, 100.0)?;
+/// let vol = surface.black_vol(Tenor(0.5), Strike(100.0))?;
 /// assert!(vol.0 > 0.0);
 /// # Ok::<(), volsurf::VolSurfError>(())
 /// ```
@@ -368,6 +370,7 @@ impl Default for SurfaceBuilder {
 mod tests {
     use super::*;
     use crate::surface::VolSurface;
+    use crate::types::{Strike, Tenor};
     use approx::assert_abs_diff_eq;
 
     /// Market data: symmetric U-shaped smile with 7 strikes.
@@ -388,7 +391,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let vol = surface.black_vol(0.25, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.25), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0, "ATM vol should be positive");
         assert!(vol.0 < 1.0, "ATM vol should be reasonable");
     }
@@ -404,15 +407,15 @@ mod tests {
             .unwrap();
 
         // Query at stored tenor
-        let vol_3m = surface.black_vol(0.25, 100.0).unwrap();
+        let vol_3m = surface.black_vol(Tenor(0.25), Strike(100.0)).unwrap();
         assert!(vol_3m.0 > 0.0);
 
         // Query between tenors
-        let vol_6m = surface.black_vol(0.5, 100.0).unwrap();
+        let vol_6m = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!(vol_6m.0 > 0.0);
 
         // Query at stored tenor
-        let vol_1y = surface.black_vol(1.0, 100.0).unwrap();
+        let vol_1y = surface.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert!(vol_1y.0 > 0.0);
     }
 
@@ -427,7 +430,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let vol = surface.black_vol(0.5, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0);
     }
 
@@ -444,7 +447,7 @@ mod tests {
         // Multiple strikes at multiple tenors
         for t in [0.25, 0.5, 1.0] {
             for k in [80.0, 90.0, 100.0, 110.0, 120.0] {
-                let vol = surface.black_vol(t, k).unwrap();
+                let vol = surface.black_vol(Tenor(t), Strike(k)).unwrap();
                 assert!(vol.0 > 0.0, "vol({t}, {k}) should be positive");
                 assert!(vol.0 < 2.0, "vol({t}, {k}) should be reasonable");
             }
@@ -463,8 +466,8 @@ mod tests {
 
         let t = 0.5;
         let k = 100.0;
-        let vol = surface.black_vol(t, k).unwrap();
-        let var = surface.black_variance(t, k).unwrap();
+        let vol = surface.black_vol(Tenor(t), Strike(k)).unwrap();
+        let var = surface.black_variance(Tenor(t), Strike(k)).unwrap();
         assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-12);
     }
 
@@ -587,7 +590,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let vol = surface.black_vol(0.5, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0);
         assert!(vol.0 < 1.0);
     }
@@ -760,7 +763,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let vol = surface.black_vol(0.5, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0, "ATM vol should be positive");
         assert!(vol.0 < 1.0, "ATM vol should be reasonable");
     }
@@ -836,13 +839,13 @@ mod tests {
             .unwrap();
 
         // Query between tenors
-        let vol = surface.black_vol(0.5, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0);
 
         // Query at/near stored tenors
         for t in [0.25, 0.5, 1.0] {
             for k in [80.0, 100.0, 120.0] {
-                let v = surface.black_vol(t, k).unwrap();
+                let v = surface.black_vol(Tenor(t), Strike(k)).unwrap();
                 assert!(
                     v.0 > 0.0 && v.0 < 2.0,
                     "vol({t}, {k}) = {} out of range",
@@ -864,8 +867,8 @@ mod tests {
 
         let t = 0.25;
         let k = 100.0;
-        let vol = surface.black_vol(t, k).unwrap();
-        let var = surface.black_variance(t, k).unwrap();
+        let vol = surface.black_vol(Tenor(t), Strike(k)).unwrap();
+        let var = surface.black_variance(Tenor(t), Strike(k)).unwrap();
         assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-12);
     }
 
@@ -907,7 +910,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let smile = surface.smile_at(1.0).unwrap();
+        let smile = surface.smile_at(Tenor(1.0)).unwrap();
         let expected_fwd = 100.0 * (0.03_f64).exp();
         assert_abs_diff_eq!(smile.forward(), expected_fwd, epsilon = 0.5);
     }
@@ -928,8 +931,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let fwd_no_q = surface_no_q.smile_at(1.0).unwrap().forward();
-        let fwd_q0 = surface_q0.smile_at(1.0).unwrap().forward();
+        let fwd_no_q = surface_no_q.smile_at(Tenor(1.0)).unwrap().forward();
+        let fwd_q0 = surface_q0.smile_at(Tenor(1.0)).unwrap().forward();
         assert_abs_diff_eq!(fwd_no_q, fwd_q0, epsilon = 1e-12);
     }
 
@@ -965,7 +968,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let smile = surface.smile_at(1.0).unwrap();
+        let smile = surface.smile_at(Tenor(1.0)).unwrap();
         // Should use the explicit 50.0, not 100*exp(0.05) ≈ 105.13
         assert_abs_diff_eq!(smile.forward(), explicit_fwd, epsilon = 1e-6);
     }
@@ -1010,7 +1013,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let vol = surface.black_vol(0.5, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.5), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
     }
 
@@ -1026,10 +1029,10 @@ mod tests {
 
         for i in 1..=10 {
             let t = i as f64 * 0.25;
-            let vol = surface.black_vol(t, 100.0).unwrap();
+            let vol = surface.black_vol(Tenor(t), Strike(100.0)).unwrap();
             assert!(vol.0 > 0.0 && vol.0 < 1.0, "bad vol {vol:?} at T={t}");
         }
-        let interp = surface.black_vol(1.375, 100.0).unwrap();
+        let interp = surface.black_vol(Tenor(1.375), Strike(100.0)).unwrap();
         assert!(interp.0 > 0.0 && interp.0 < 1.0);
     }
 
@@ -1060,7 +1063,7 @@ mod tests {
             builder = builder.add_tenor(i as f64 * 0.25, &strikes, &vols);
         }
         let surface = builder.build().unwrap();
-        let vol = surface.black_vol(1.0, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
     }
 
@@ -1076,7 +1079,7 @@ mod tests {
             builder = builder.add_tenor(i as f64 * 0.25, &strikes, &vols);
         }
         let surface = builder.build().unwrap();
-        let vol = surface.black_vol(1.0, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
     }
 

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -1153,6 +1153,22 @@ mod tests {
     }
 
     #[test]
+    fn vol_rejects_nan_strike() {
+        let s = equity_slice();
+        assert!(s.vol(Strike(f64::NAN)).is_err());
+        assert!(s.variance(Strike(f64::NAN)).is_err());
+    }
+
+    #[test]
+    fn vol_rejects_inf_strike() {
+        let s = equity_slice();
+        assert!(s.vol(Strike(f64::INFINITY)).is_err());
+        assert!(s.vol(Strike(f64::NEG_INFINITY)).is_err());
+        assert!(s.variance(Strike(f64::INFINITY)).is_err());
+        assert!(s.variance(Strike(f64::NEG_INFINITY)).is_err());
+    }
+
+    #[test]
     fn skew_direction() {
         let s = equity_slice();
         let vol_put = s.vol(Strike(80.0)).unwrap().0;
@@ -1911,6 +1927,27 @@ mod tests {
         assert!(s.black_vol(Tenor(1.0), Strike(0.0)).is_err());
         assert!(s.black_vol(Tenor(1.0), Strike(-100.0)).is_err());
         assert!(s.black_variance(Tenor(1.0), Strike(0.0)).is_err());
+    }
+
+    #[test]
+    fn surface_rejects_nan_inputs() {
+        let s = equity_surface();
+        assert!(s.black_vol(Tenor(f64::NAN), Strike(100.0)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(f64::NAN)).is_err());
+        assert!(s.black_variance(Tenor(f64::NAN), Strike(100.0)).is_err());
+    }
+
+    #[test]
+    fn surface_rejects_inf_inputs() {
+        let s = equity_surface();
+        assert!(s.black_vol(Tenor(f64::INFINITY), Strike(100.0)).is_err());
+        assert!(
+            s.black_vol(Tenor(f64::NEG_INFINITY), Strike(100.0))
+                .is_err()
+        );
+        assert!(s.black_vol(Tenor(1.0), Strike(f64::INFINITY)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(f64::NEG_INFINITY)).is_err());
+        assert!(s.smile_at(Tenor(f64::INFINITY)).is_err());
     }
 
     #[test]

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -20,7 +20,7 @@ use crate::surface::CALENDAR_ARB_TOL;
 use crate::surface::VolSurface;
 use crate::surface::arbitrage::{CalendarViolation, SurfaceDiagnostics};
 use crate::surface::ssvi::{CALENDAR_CHECK_GRID_SIZE, SsviSlice, strike_grid};
-use crate::types::{Variance, Vol};
+use crate::types::{Strike, Tenor, Variance, Vol};
 use crate::validate::validate_positive;
 
 /// A structural calendar no-arb violation (Thm 4.1, Eq 4.10).
@@ -149,10 +149,10 @@ impl EssviSlice {
     ///
     /// ```
     /// use volsurf::surface::EssviSlice;
-    /// use volsurf::SmileSection;
+    /// use volsurf::{SmileSection, Strike};
     ///
     /// let slice = EssviSlice::new(100.0, 1.0, -0.3, 0.5, 0.5, 0.04)?;
-    /// let vol = slice.vol(100.0)?;
+    /// let vol = slice.vol(Strike(100.0))?;
     /// assert!((vol.0 - 0.20).abs() < 0.01);
     /// # Ok::<(), volsurf::VolSurfError>(())
     /// ```
@@ -189,15 +189,15 @@ impl EssviSlice {
 }
 
 impl SmileSection for EssviSlice {
-    fn vol(&self, strike: f64) -> error::Result<Vol> {
+    fn vol(&self, strike: Strike) -> error::Result<Vol> {
         self.0.vol(strike)
     }
 
-    fn variance(&self, strike: f64) -> error::Result<Variance> {
+    fn variance(&self, strike: Strike) -> error::Result<Variance> {
         self.0.variance(strike)
     }
 
-    fn density(&self, strike: f64) -> error::Result<f64> {
+    fn density(&self, strike: Strike) -> error::Result<f64> {
         self.0.density(strike)
     }
 
@@ -516,11 +516,11 @@ impl EssviSurface {
                     model: "eSSVI",
                     rms_error: None,
                 })?;
-            let theta = svi.variance(forwards[i])?.0;
+            let theta = svi.variance(Strike(forwards[i]))?.0;
 
             let mut sum_sq = 0.0;
             for &(strike, market_vol) in market_vols {
-                let fitted_vol = svi.vol(strike)?.0;
+                let fitted_vol = svi.vol(Strike(strike))?.0;
                 sum_sq += (fitted_vol - market_vol).powi(2);
             }
             let rms_error = (sum_sq / market_vols.len() as f64).sqrt();
@@ -980,17 +980,17 @@ impl EssviSurface {
 }
 
 impl VolSurface for EssviSurface {
-    fn black_vol(&self, expiry: f64, strike: f64) -> error::Result<Vol> {
-        validate_positive(expiry, "expiry")?;
+    fn black_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol> {
+        validate_positive(expiry.0, "expiry")?;
         let var = self.black_variance(expiry, strike)?;
-        Ok(Vol((var.0 / expiry).sqrt()))
+        Ok(Vol((var.0 / expiry.0).sqrt()))
     }
 
-    fn black_variance(&self, expiry: f64, strike: f64) -> error::Result<Variance> {
-        validate_positive(expiry, "expiry")?;
-        validate_positive(strike, "strike")?;
-        let (theta, forward) = self.theta_and_forward_at(expiry);
-        let k = (strike / forward).ln();
+    fn black_variance(&self, expiry: Tenor, strike: Strike) -> error::Result<Variance> {
+        validate_positive(expiry.0, "expiry")?;
+        validate_positive(strike.0, "strike")?;
+        let (theta, forward) = self.theta_and_forward_at(expiry.0);
+        let k = (strike.0 / forward).ln();
         let w = self.total_variance_at(theta, k);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -1000,11 +1000,11 @@ impl VolSurface for EssviSurface {
         Ok(Variance(w))
     }
 
-    fn smile_at(&self, expiry: f64) -> error::Result<Box<dyn SmileSection>> {
-        validate_positive(expiry, "expiry")?;
-        let (theta, forward) = self.theta_and_forward_at(expiry);
+    fn smile_at(&self, expiry: Tenor) -> error::Result<Box<dyn SmileSection>> {
+        validate_positive(expiry.0, "expiry")?;
+        let (theta, forward) = self.theta_and_forward_at(expiry.0);
         let rho = self.rho(theta);
-        let slice = EssviSlice::new(forward, expiry, rho, self.eta, self.gamma, theta)?;
+        let slice = EssviSlice::new(forward, expiry.0, rho, self.eta, self.gamma, theta)?;
         Ok(Box::new(slice))
     }
 
@@ -1111,14 +1111,14 @@ mod tests {
     fn vol_atm_equals_sqrt_theta_over_t() {
         // ATM: k = 0, w(0) = theta, vol = sqrt(theta / T) = sqrt(0.16) = 0.4
         let s = equity_slice();
-        let vol = s.vol(100.0).unwrap();
+        let vol = s.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.4, epsilon = 1e-10);
     }
 
     #[test]
     fn variance_atm_equals_theta() {
         let s = equity_slice();
-        let var = s.variance(100.0).unwrap();
+        let var = s.variance(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(var.0, 0.16, epsilon = 1e-14);
     }
 
@@ -1126,8 +1126,8 @@ mod tests {
     fn vol_variance_consistency() {
         let s = equity_slice();
         for &strike in &[80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = s.vol(strike).unwrap();
-            let var = s.variance(strike).unwrap();
+            let vol = s.vol(Strike(strike)).unwrap();
+            let var = s.variance(Strike(strike)).unwrap();
             assert_abs_diff_eq!(var.0, vol.0 * vol.0 * s.expiry(), epsilon = 1e-14);
         }
     }
@@ -1138,8 +1138,8 @@ mod tests {
         let essvi = equity_slice();
         let ssvi = SsviSlice::new(100.0, 1.0, -0.3, 0.5, 0.5, 0.16).unwrap();
         for &strike in &[70.0, 85.0, 100.0, 115.0, 130.0] {
-            let v_essvi = essvi.vol(strike).unwrap().0;
-            let v_ssvi = ssvi.vol(strike).unwrap().0;
+            let v_essvi = essvi.vol(Strike(strike)).unwrap().0;
+            let v_ssvi = ssvi.vol(Strike(strike)).unwrap().0;
             assert_eq!(v_essvi.to_bits(), v_ssvi.to_bits(), "strike={strike}");
         }
     }
@@ -1147,16 +1147,16 @@ mod tests {
     #[test]
     fn vol_rejects_non_positive_strikes() {
         let s = equity_slice();
-        assert!(s.vol(0.0).is_err());
-        assert!(s.vol(-100.0).is_err());
-        assert!(s.variance(0.0).is_err());
+        assert!(s.vol(Strike(0.0)).is_err());
+        assert!(s.vol(Strike(-100.0)).is_err());
+        assert!(s.variance(Strike(0.0)).is_err());
     }
 
     #[test]
     fn skew_direction() {
         let s = equity_slice();
-        let vol_put = s.vol(80.0).unwrap().0;
-        let vol_call = s.vol(120.0).unwrap().0;
+        let vol_put = s.vol(Strike(80.0)).unwrap().0;
+        let vol_call = s.vol(Strike(120.0)).unwrap().0;
         assert!(vol_put > vol_call, "negative rho should produce put skew");
     }
 
@@ -1164,7 +1164,7 @@ mod tests {
     fn density_positive_near_atm() {
         let s = equity_slice();
         for &strike in &[90.0, 95.0, 100.0, 105.0, 110.0] {
-            let d = s.density(strike).unwrap();
+            let d = s.density(Strike(strike)).unwrap();
             assert!(d > 0.0, "density({strike}) = {d}");
         }
     }
@@ -1192,7 +1192,7 @@ mod tests {
         let report = s.is_arbitrage_free().unwrap();
         assert!(!report.butterfly_violations.is_empty());
         for v in &report.butterfly_violations {
-            let expected = s.density(v.strike).unwrap();
+            let expected = s.density(Strike(v.strike)).unwrap();
             assert_abs_diff_eq!(v.density, expected, epsilon = 1e-14);
             assert_abs_diff_eq!(v.magnitude, expected.abs(), epsilon = 1e-14);
         }
@@ -1216,8 +1216,8 @@ mod tests {
         assert_eq!(s.eta(), s2.eta());
         assert_eq!(s.gamma(), s2.gamma());
         assert_abs_diff_eq!(
-            s.vol(90.0).unwrap().0,
-            s2.vol(90.0).unwrap().0,
+            s.vol(Strike(90.0)).unwrap().0,
+            s2.vol(Strike(90.0)).unwrap().0,
             epsilon = 1e-14
         );
     }
@@ -1275,7 +1275,7 @@ mod tests {
         let t = 7.0 / 365.0;
         let theta = 0.04 * t;
         let s = EssviSlice::new(100.0, t, -0.5, 0.8, 0.4, theta).unwrap();
-        let vol = s.vol(100.0).unwrap();
+        let vol = s.vol(Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0 && vol.0 < 2.0);
     }
 
@@ -1283,7 +1283,7 @@ mod tests {
     fn long_expiry_slice() {
         // 5-year tenor
         let s = EssviSlice::new(100.0, 5.0, -0.2, 0.3, 0.6, 0.50).unwrap();
-        let vol = s.vol(100.0).unwrap();
+        let vol = s.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, (0.50 / 5.0_f64).sqrt(), epsilon = 1e-10);
     }
 
@@ -1812,7 +1812,7 @@ mod tests {
     fn surface_atm_variance_at_stored_tenor() {
         let s = equity_surface();
         for (i, &t) in s.tenors().iter().enumerate() {
-            let var = s.black_variance(t, s.forwards()[i]).unwrap();
+            let var = s.black_variance(Tenor(t), Strike(s.forwards()[i])).unwrap();
             assert_abs_diff_eq!(var.0, s.thetas()[i], epsilon = 1e-12);
         }
     }
@@ -1821,7 +1821,7 @@ mod tests {
     fn surface_atm_vol_at_stored_tenor() {
         let s = equity_surface();
         for (i, &t) in s.tenors().iter().enumerate() {
-            let vol = s.black_vol(t, s.forwards()[i]).unwrap();
+            let vol = s.black_vol(Tenor(t), Strike(s.forwards()[i])).unwrap();
             let expected = (s.thetas()[i] / t).sqrt();
             assert_abs_diff_eq!(vol.0, expected, epsilon = 1e-10);
         }
@@ -1832,8 +1832,8 @@ mod tests {
         let s = equity_surface();
         for &t in &[0.25, 0.5, 1.0, 2.0] {
             for &k in &[80.0, 90.0, 100.0, 110.0, 120.0] {
-                let vol = s.black_vol(t, k).unwrap();
-                let var = s.black_variance(t, k).unwrap();
+                let vol = s.black_vol(Tenor(t), Strike(k)).unwrap();
+                let var = s.black_variance(Tenor(t), Strike(k)).unwrap();
                 assert_abs_diff_eq!(var.0, vol.0 * vol.0 * t, epsilon = 1e-12);
             }
         }
@@ -1844,7 +1844,7 @@ mod tests {
         let s = equity_surface();
         for &t in &[0.25, 0.5, 1.0, 2.0] {
             for &k in &[60.0, 80.0, 100.0, 120.0, 150.0] {
-                let var = s.black_variance(t, k).unwrap();
+                let var = s.black_variance(Tenor(t), Strike(k)).unwrap();
                 assert!(var.0 > 0.0, "variance should be positive at T={t}, K={k}");
             }
         }
@@ -1854,8 +1854,8 @@ mod tests {
     fn surface_skew_matches_rho_sign() {
         let s = equity_surface(); // rho < 0 everywhere
         for &t in s.tenors() {
-            let vol_put = s.black_vol(t, 80.0).unwrap().0;
-            let vol_call = s.black_vol(t, 120.0).unwrap().0;
+            let vol_put = s.black_vol(Tenor(t), Strike(80.0)).unwrap().0;
+            let vol_call = s.black_vol(Tenor(t), Strike(120.0)).unwrap().0;
             assert!(
                 vol_put > vol_call,
                 "negative rho should produce put skew at T={t}"
@@ -1867,12 +1867,12 @@ mod tests {
     fn surface_interpolation_between_tenors() {
         let s = equity_surface();
         // T=0.75 is between tenor[1]=0.5 and tenor[2]=1.0
-        let vol = s.black_vol(0.75, 100.0).unwrap();
+        let vol = s.black_vol(Tenor(0.75), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
         // variance should interpolate monotonically between neighbors
-        let var = s.black_variance(0.75, 100.0).unwrap().0;
-        let var_lo = s.black_variance(0.5, 100.0).unwrap().0;
-        let var_hi = s.black_variance(1.0, 100.0).unwrap().0;
+        let var = s.black_variance(Tenor(0.75), Strike(100.0)).unwrap().0;
+        let var_lo = s.black_variance(Tenor(0.5), Strike(100.0)).unwrap().0;
+        let var_hi = s.black_variance(Tenor(1.0), Strike(100.0)).unwrap().0;
         assert!(
             var > var_lo && var < var_hi,
             "variance should interpolate monotonically"
@@ -1883,7 +1883,7 @@ mod tests {
     fn surface_extrapolation_before_first_tenor() {
         let s = equity_surface();
         // T=0.1 < tenor[0]=0.25: flat vol extrapolation => theta = theta_0 * T/T_0
-        let var = s.black_variance(0.1, 100.0).unwrap();
+        let var = s.black_variance(Tenor(0.1), Strike(100.0)).unwrap();
         let expected_theta = 0.04 * 0.1 / 0.25;
         assert_abs_diff_eq!(var.0, expected_theta, epsilon = 1e-12);
     }
@@ -1892,7 +1892,7 @@ mod tests {
     fn surface_extrapolation_after_last_tenor() {
         let s = equity_surface();
         // T=3.0 > tenor[3]=2.0: flat vol extrapolation => theta = theta_n * T/T_n
-        let var = s.black_variance(3.0, 100.0).unwrap();
+        let var = s.black_variance(Tenor(3.0), Strike(100.0)).unwrap();
         let expected_theta = 0.32 * 3.0 / 2.0;
         assert_abs_diff_eq!(var.0, expected_theta, epsilon = 1e-12);
     }
@@ -1900,47 +1900,47 @@ mod tests {
     #[test]
     fn surface_rejects_non_positive_expiry() {
         let s = equity_surface();
-        assert!(s.black_vol(0.0, 100.0).is_err());
-        assert!(s.black_vol(-1.0, 100.0).is_err());
-        assert!(s.black_variance(0.0, 100.0).is_err());
+        assert!(s.black_vol(Tenor(0.0), Strike(100.0)).is_err());
+        assert!(s.black_vol(Tenor(-1.0), Strike(100.0)).is_err());
+        assert!(s.black_variance(Tenor(0.0), Strike(100.0)).is_err());
     }
 
     #[test]
     fn surface_rejects_non_positive_strike() {
         let s = equity_surface();
-        assert!(s.black_vol(1.0, 0.0).is_err());
-        assert!(s.black_vol(1.0, -100.0).is_err());
-        assert!(s.black_variance(1.0, 0.0).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(0.0)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(-100.0)).is_err());
+        assert!(s.black_variance(Tenor(1.0), Strike(0.0)).is_err());
     }
 
     #[test]
     fn surface_smile_at_returns_essvi_slice() {
         let s = equity_surface();
-        let smile = s.smile_at(1.0).unwrap();
+        let smile = s.smile_at(Tenor(1.0)).unwrap();
         assert_eq!(smile.forward(), 100.0);
         assert_abs_diff_eq!(smile.expiry(), 1.0, epsilon = 1e-10);
         // vol at ATM should match surface query
-        let smile_vol = smile.vol(100.0).unwrap().0;
-        let surface_vol = s.black_vol(1.0, 100.0).unwrap().0;
+        let smile_vol = smile.vol(Strike(100.0)).unwrap().0;
+        let surface_vol = s.black_vol(Tenor(1.0), Strike(100.0)).unwrap().0;
         assert_abs_diff_eq!(smile_vol, surface_vol, epsilon = 1e-14);
     }
 
     #[test]
     fn surface_smile_at_interpolated_tenor() {
         let s = equity_surface();
-        let smile = s.smile_at(0.75).unwrap();
+        let smile = s.smile_at(Tenor(0.75)).unwrap();
         assert!(smile.expiry() > 0.0);
         // vol at ATM should match the direct surface query
-        let smile_vol = smile.vol(smile.forward()).unwrap().0;
-        let surface_vol = s.black_vol(0.75, smile.forward()).unwrap().0;
+        let smile_vol = smile.vol(Strike(smile.forward())).unwrap().0;
+        let surface_vol = s.black_vol(Tenor(0.75), Strike(smile.forward())).unwrap().0;
         assert_abs_diff_eq!(smile_vol, surface_vol, epsilon = 1e-12);
     }
 
     #[test]
     fn surface_smile_at_rejects_non_positive() {
         let s = equity_surface();
-        assert!(s.smile_at(0.0).is_err());
-        assert!(s.smile_at(-1.0).is_err());
+        assert!(s.smile_at(Tenor(0.0)).is_err());
+        assert!(s.smile_at(Tenor(-1.0)).is_err());
     }
 
     #[test]
@@ -1973,11 +1973,11 @@ mod tests {
     #[test]
     fn surface_rho_differs_per_tenor_in_smile() {
         let s = equity_surface();
-        let smile_short = s.smile_at(0.25).unwrap();
-        let smile_long = s.smile_at(2.0).unwrap();
+        let smile_short = s.smile_at(Tenor(0.25)).unwrap();
+        let smile_long = s.smile_at(Tenor(2.0)).unwrap();
         // OTM put vol should differ due to different rho at each tenor
-        let vol_short = smile_short.vol(80.0).unwrap().0;
-        let vol_long = smile_long.vol(80.0).unwrap().0;
+        let vol_short = smile_short.vol(Strike(80.0)).unwrap().0;
+        let vol_long = smile_long.vol(Strike(80.0)).unwrap().0;
         // They shouldn't be identical (different rho at each theta)
         assert!(
             (vol_short - vol_long).abs() > 1e-6,
@@ -2000,8 +2000,8 @@ mod tests {
         assert_eq!(s.thetas(), s2.thetas());
         assert_eq!(s.theta_max(), s2.theta_max());
         // vol query should be identical
-        let v1 = s.black_vol(1.0, 90.0).unwrap().0;
-        let v2 = s2.black_vol(1.0, 90.0).unwrap().0;
+        let v1 = s.black_vol(Tenor(1.0), Strike(90.0)).unwrap().0;
+        let v2 = s2.black_vol(Tenor(1.0), Strike(90.0)).unwrap().0;
         assert_eq!(v1.to_bits(), v2.to_bits());
     }
 
@@ -2076,7 +2076,7 @@ mod tests {
             .map(|(&t, strikes)| {
                 strikes
                     .iter()
-                    .map(|&k| (k, surface.black_vol(t, k).unwrap().0))
+                    .map(|&k| (k, surface.black_vol(Tenor(t), Strike(k)).unwrap().0))
                     .collect()
             })
             .collect()
@@ -2091,7 +2091,7 @@ mod tests {
         let mut n_points = 0;
         for (i, &t) in tenors.iter().enumerate() {
             for &(strike, vol_obs) in &market_data[i] {
-                let vol_fit = calibrated.black_vol(t, strike).unwrap().0;
+                let vol_fit = calibrated.black_vol(Tenor(t), Strike(strike)).unwrap().0;
                 total_rss += (vol_fit - vol_obs).powi(2);
                 n_points += 1;
             }
@@ -2274,8 +2274,8 @@ mod tests {
         for (a, b) in calibrated.thetas().iter().zip(deserialized.thetas()) {
             assert_abs_diff_eq!(a, b, epsilon = 1e-14);
         }
-        let v1 = calibrated.black_vol(1.0, 90.0).unwrap().0;
-        let v2 = deserialized.black_vol(1.0, 90.0).unwrap().0;
+        let v1 = calibrated.black_vol(Tenor(1.0), Strike(90.0)).unwrap().0;
+        let v2 = deserialized.black_vol(Tenor(1.0), Strike(90.0)).unwrap().0;
         assert_abs_diff_eq!(v1, v2, epsilon = 1e-14);
     }
 
@@ -2427,7 +2427,9 @@ mod tests {
             .zip(&strikes)
             .map(|((&t, &(a, b, rho)), ks)| {
                 let svi = SviSmile::new(100.0, t, a, b, rho, 0.0, 0.1).unwrap();
-                ks.iter().map(|&k| (k, svi.vol(k).unwrap().0)).collect()
+                ks.iter()
+                    .map(|&k| (k, svi.vol(Strike(k)).unwrap().0))
+                    .collect()
             })
             .collect();
 
@@ -2650,7 +2652,7 @@ mod tests {
         match EssviSurface::calibrate(&market_data, &tenors, &forwards) {
             Ok(surface) => {
                 for (&t, &f) in tenors.iter().zip(forwards.iter()) {
-                    let vol = surface.black_vol(t, f).unwrap().0;
+                    let vol = surface.black_vol(Tenor(t), Strike(f)).unwrap().0;
                     assert!(
                         vol.is_finite() && vol > 0.0,
                         "ATM vol at T={t} should be finite and positive, got {vol}"
@@ -2727,7 +2729,7 @@ mod tests {
         assert_eq!(pruned.len(), 3);
 
         let surface = EssviSurface::from_per_tenor(&pruned).unwrap();
-        let vol = surface.black_vol(1.0, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert!(vol.0 > 0.0 && vol.0 < 1.0, "vol {:.4} out of range", vol.0);
     }
 
@@ -2755,8 +2757,8 @@ mod tests {
 
         for &t in &[0.25, 0.5, 1.0, 2.0] {
             for &k in &[80.0, 100.0, 120.0] {
-                let v1 = one_shot.black_vol(t, k).unwrap();
-                let v2 = two_stage.black_vol(t, k).unwrap();
+                let v1 = one_shot.black_vol(Tenor(t), Strike(k)).unwrap();
+                let v2 = two_stage.black_vol(Tenor(t), Strike(k)).unwrap();
                 assert_eq!(v1.0, v2.0, "vol mismatch at t={t}, k={k}");
             }
         }

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -27,7 +27,7 @@ pub(crate) const EXPIRY_MATCH_TOL: f64 = 1e-10;
 
 use crate::error;
 use crate::smile::SmileSection;
-use crate::types::{Variance, Vol};
+use crate::types::{Strike, Tenor, Variance, Vol};
 
 /// A full volatility surface: (expiry, strike) → vol.
 ///
@@ -46,6 +46,7 @@ use crate::types::{Variance, Vol};
 ///
 /// ```
 /// use volsurf::surface::{SsviSurface, VolSurface};
+/// use volsurf::types::{Strike, Tenor};
 ///
 /// let surface = SsviSurface::new(
 ///     -0.3, 0.5, 0.5,
@@ -54,14 +55,14 @@ use crate::types::{Variance, Vol};
 ///     vec![0.04, 0.08, 0.16],
 /// )?;
 ///
-/// let vol = surface.black_vol(0.5, 100.0)?;
+/// let vol = surface.black_vol(Tenor(0.5), Strike(100.0))?;
 /// assert!(vol.0 > 0.0);
 ///
-/// let var = surface.black_variance(0.5, 100.0)?;
+/// let var = surface.black_variance(Tenor(0.5), Strike(100.0))?;
 /// assert!((var.0 - vol.0 * vol.0 * 0.5).abs() < 1e-12);
 ///
-/// let smile = surface.smile_at(0.5)?;
-/// assert!(smile.vol(100.0)?.0 > 0.0);
+/// let smile = surface.smile_at(Tenor(0.5))?;
+/// assert!(smile.vol(Strike(100.0))?.0 > 0.0);
 /// # Ok::<(), volsurf::VolSurfError>(())
 /// ```
 pub trait VolSurface: Send + Sync + std::fmt::Debug {
@@ -71,13 +72,13 @@ pub trait VolSurface: Send + Sync + std::fmt::Debug {
     /// which also maps (T, K) → σ but means the instantaneous diffusion
     /// coefficient. [`SmileSection::vol`] omits the prefix because there is
     /// no ambiguity at the single-tenor level.
-    fn black_vol(&self, expiry: f64, strike: f64) -> error::Result<Vol>;
+    fn black_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol>;
 
     /// Black total variance σ²(T, K) · T.
     ///
     /// Cross-tenor interpolation is performed in variance space because
     /// total variance must be non-decreasing in time for no-arbitrage.
-    fn black_variance(&self, expiry: f64, strike: f64) -> error::Result<Variance>;
+    fn black_variance(&self, expiry: Tenor, strike: Strike) -> error::Result<Variance>;
 
     /// A smile section at the given expiry.
     ///
@@ -86,7 +87,7 @@ pub trait VolSurface: Send + Sync + std::fmt::Debug {
     /// there is no stored object to borrow. A reference return would require
     /// interior mutability. The heap allocation is acceptable: `smile_at()`
     /// is called once per tenor setup, not per option.
-    fn smile_at(&self, expiry: f64) -> error::Result<Box<dyn SmileSection>>;
+    fn smile_at(&self, expiry: Tenor) -> error::Result<Box<dyn SmileSection>>;
 
     /// Surface-level arbitrage diagnostics (butterfly + calendar).
     fn diagnostics(&self) -> error::Result<SurfaceDiagnostics>;

--- a/src/surface/piecewise.rs
+++ b/src/surface/piecewise.rs
@@ -30,7 +30,7 @@ use crate::smile::spline::SplineSmile;
 use crate::surface::VolSurface;
 use crate::surface::arbitrage::{CalendarViolation, SurfaceDiagnostics};
 use crate::surface::{CALENDAR_ARB_TOL, EXPIRY_MATCH_TOL};
-use crate::types::{Variance, Vol};
+use crate::types::{Strike, Tenor, Variance, Vol};
 use crate::validate::validate_positive;
 
 /// Number of strikes used when sampling smiles for interpolation.
@@ -175,36 +175,36 @@ enum TenorPosition {
 }
 
 impl VolSurface for PiecewiseSurface {
-    fn black_vol(&self, expiry: f64, strike: f64) -> error::Result<Vol> {
-        validate_positive(expiry, "expiry")?;
+    fn black_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol> {
+        validate_positive(expiry.0, "expiry")?;
         let var = self.black_variance(expiry, strike)?;
-        Ok(Vol((var.0 / expiry).sqrt()))
+        Ok(Vol((var.0 / expiry.0).sqrt()))
     }
 
-    fn black_variance(&self, expiry: f64, strike: f64) -> error::Result<Variance> {
-        validate_positive(expiry, "expiry")?;
-        validate_positive(strike, "strike")?;
+    fn black_variance(&self, expiry: Tenor, strike: Strike) -> error::Result<Variance> {
+        validate_positive(expiry.0, "expiry")?;
+        validate_positive(strike.0, "strike")?;
 
-        match self.locate_tenor(expiry) {
+        match self.locate_tenor(expiry.0) {
             TenorPosition::Exact(i) => self.smiles[i].variance(strike),
 
             TenorPosition::Before => {
                 // Flat vol extrapolation: w(T, K) = w(T1, K) · T/T1
                 let w1 = self.smiles[0].variance(strike)?;
-                Ok(Variance(w1.0 * expiry / self.tenors[0]))
+                Ok(Variance(w1.0 * expiry.0 / self.tenors[0]))
             }
 
             TenorPosition::After => {
                 // Flat vol extrapolation: w(T, K) = w(Tn, K) · T/Tn
                 let n = self.tenors.len();
                 let wn = self.smiles[n - 1].variance(strike)?;
-                Ok(Variance(wn.0 * expiry / self.tenors[n - 1]))
+                Ok(Variance(wn.0 * expiry.0 / self.tenors[n - 1]))
             }
 
             TenorPosition::Between(i, j) => {
                 let t1 = self.tenors[i];
                 let t2 = self.tenors[j];
-                let alpha = (expiry - t1) / (t2 - t1);
+                let alpha = (expiry.0 - t1) / (t2 - t1);
                 let w1 = self.smiles[i].variance(strike)?;
                 let w2 = self.smiles[j].variance(strike)?;
                 Ok(Variance((1.0 - alpha) * w1.0 + alpha * w2.0))
@@ -212,17 +212,17 @@ impl VolSurface for PiecewiseSurface {
         }
     }
 
-    fn smile_at(&self, expiry: f64) -> error::Result<Box<dyn SmileSection>> {
-        validate_positive(expiry, "expiry")?;
+    fn smile_at(&self, expiry: Tenor) -> error::Result<Box<dyn SmileSection>> {
+        validate_positive(expiry.0, "expiry")?;
 
         // Determine the forward and strike grid for the interpolated smile
-        let (forward, strikes, variances) = match self.locate_tenor(expiry) {
+        let (forward, strikes, variances) = match self.locate_tenor(expiry.0) {
             TenorPosition::Exact(i) => {
                 let fwd = self.smiles[i].forward();
                 let grid = Self::strike_grid(fwd, SMILE_GRID_SIZE);
                 let vars: error::Result<Vec<f64>> = grid
                     .iter()
-                    .map(|&k| self.smiles[i].variance(k).map(|v| v.0))
+                    .map(|&k| self.smiles[i].variance(Strike(k)).map(|v| v.0))
                     .collect();
                 (fwd, grid, vars?)
             }
@@ -231,10 +231,10 @@ impl VolSurface for PiecewiseSurface {
                 let fwd = self.smiles[0].forward();
                 let grid = Self::strike_grid(fwd, SMILE_GRID_SIZE);
                 let t1 = self.tenors[0];
-                let scale = expiry / t1;
+                let scale = expiry.0 / t1;
                 let vars: error::Result<Vec<f64>> = grid
                     .iter()
-                    .map(|&k| self.smiles[0].variance(k).map(|v| v.0 * scale))
+                    .map(|&k| self.smiles[0].variance(Strike(k)).map(|v| v.0 * scale))
                     .collect();
                 (fwd, grid, vars?)
             }
@@ -244,10 +244,10 @@ impl VolSurface for PiecewiseSurface {
                 let fwd = self.smiles[n - 1].forward();
                 let grid = Self::strike_grid(fwd, SMILE_GRID_SIZE);
                 let tn = self.tenors[n - 1];
-                let scale = expiry / tn;
+                let scale = expiry.0 / tn;
                 let vars: error::Result<Vec<f64>> = grid
                     .iter()
-                    .map(|&k| self.smiles[n - 1].variance(k).map(|v| v.0 * scale))
+                    .map(|&k| self.smiles[n - 1].variance(Strike(k)).map(|v| v.0 * scale))
                     .collect();
                 (fwd, grid, vars?)
             }
@@ -257,14 +257,14 @@ impl VolSurface for PiecewiseSurface {
                 let f2 = self.smiles[j].forward();
                 let t1 = self.tenors[i];
                 let t2 = self.tenors[j];
-                let alpha = (expiry - t1) / (t2 - t1);
+                let alpha = (expiry.0 - t1) / (t2 - t1);
                 let fwd = (f1.ln() * (1.0 - alpha) + f2.ln() * alpha).exp();
                 let grid = Self::strike_grid(fwd, SMILE_GRID_SIZE);
                 let vars: error::Result<Vec<f64>> = grid
                     .iter()
                     .map(|&k| {
-                        let w1 = self.smiles[i].variance(k)?.0;
-                        let w2 = self.smiles[j].variance(k)?.0;
+                        let w1 = self.smiles[i].variance(Strike(k))?.0;
+                        let w2 = self.smiles[j].variance(Strike(k))?.0;
                         Ok((1.0 - alpha) * w1 + alpha * w2)
                     })
                     .collect();
@@ -272,7 +272,7 @@ impl VolSurface for PiecewiseSurface {
             }
         };
 
-        let spline = SplineSmile::new(forward, expiry, strikes, variances)?;
+        let spline = SplineSmile::new(forward, expiry.0, strikes, variances)?;
         Ok(Box::new(spline))
     }
 
@@ -292,8 +292,8 @@ impl VolSurface for PiecewiseSurface {
             let grid = Self::strike_grid(fwd_avg, CALENDAR_CHECK_GRID_SIZE);
 
             for &k in &grid {
-                let w_short = self.smiles[i].variance(k)?;
-                let w_long = self.smiles[i + 1].variance(k)?;
+                let w_short = self.smiles[i].variance(Strike(k))?;
+                let w_long = self.smiles[i + 1].variance(Strike(k))?;
                 if w_long.0 < w_short.0 - CALENDAR_ARB_TOL {
                     calendar_violations.push(CalendarViolation {
                         strike: k,
@@ -320,6 +320,7 @@ impl VolSurface for PiecewiseSurface {
 mod tests {
     use super::*;
     use crate::smile::spline::SplineSmile;
+    use crate::types::{Strike, Tenor};
     use approx::assert_abs_diff_eq;
 
     /// Helper: create a flat-vol SplineSmile at a given tenor.
@@ -406,11 +407,11 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![0.25, 1.0], vec![s1, s2]).unwrap();
 
         // Query at T=0.25 should return 20% vol
-        let vol = surface.black_vol(0.25, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(0.25), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.20, epsilon = 1e-10);
 
         // Query at T=1.0 should return 25% vol
-        let vol = surface.black_vol(1.0, 100.0).unwrap();
+        let vol = surface.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.25, epsilon = 1e-10);
     }
 
@@ -429,7 +430,7 @@ mod tests {
         let w2 = vol2 * vol2 * t2; // 0.09
         let w_mid = 0.5 * w1 + 0.5 * w2; // 0.055
 
-        let var = surface.black_variance(t_mid, 100.0).unwrap();
+        let var = surface.black_variance(Tenor(t_mid), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(var.0, w_mid, epsilon = 1e-10);
     }
 
@@ -441,8 +442,8 @@ mod tests {
 
         for t in [0.1, 0.25, 0.5, 0.75, 1.0, 1.5] {
             for k in [80.0, 100.0, 120.0] {
-                let vol = surface.black_vol(t, k).unwrap();
-                let var = surface.black_variance(t, k).unwrap();
+                let vol = surface.black_vol(Tenor(t), Strike(k)).unwrap();
+                let var = surface.black_variance(Tenor(t), Strike(k)).unwrap();
                 assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-12);
             }
         }
@@ -458,7 +459,7 @@ mod tests {
         // At T=0.25 (before first tenor), flat vol extrapolation:
         // w(0.25, K) = w(0.5, K) * 0.25/0.5 = sigma^2 * 0.5 * 0.5 = sigma^2 * 0.25
         let query_t = 0.25;
-        let v = surface.black_vol(query_t, 100.0).unwrap();
+        let v = surface.black_vol(Tenor(query_t), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(v.0, vol, epsilon = 1e-10);
     }
 
@@ -470,7 +471,7 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![t1], vec![s1]).unwrap();
 
         // At T=2.0 (after last tenor), flat vol extrapolation
-        let v = surface.black_vol(2.0, 100.0).unwrap();
+        let v = surface.black_vol(Tenor(2.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(v.0, vol, epsilon = 1e-10);
     }
 
@@ -479,8 +480,8 @@ mod tests {
         let s1 = flat_smile(100.0, 1.0, 0.20);
         let surface = PiecewiseSurface::new(vec![1.0], vec![s1]).unwrap();
 
-        let smile = surface.smile_at(1.0).unwrap();
-        let vol = smile.vol(100.0).unwrap();
+        let smile = surface.smile_at(Tenor(1.0)).unwrap();
+        let vol = smile.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.20, epsilon = 1e-4);
         assert_abs_diff_eq!(smile.expiry(), 1.0, epsilon = 1e-14);
     }
@@ -491,11 +492,11 @@ mod tests {
         let s2 = flat_smile(100.0, 1.0, 0.30);
         let surface = PiecewiseSurface::new(vec![0.5, 1.0], vec![s1, s2]).unwrap();
 
-        let smile = surface.smile_at(0.75).unwrap();
+        let smile = surface.smile_at(Tenor(0.75)).unwrap();
         assert_abs_diff_eq!(smile.expiry(), 0.75, epsilon = 1e-14);
 
         // Check that the interpolated variance is between the two smiles
-        let var = smile.variance(100.0).unwrap();
+        let var = smile.variance(Strike(100.0)).unwrap();
         let w1 = 0.20 * 0.20 * 0.5;
         let w2 = 0.30 * 0.30 * 1.0;
         let w_expected = 0.5 * w1 + 0.5 * w2;
@@ -508,11 +509,11 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![1.0], vec![s1]).unwrap();
 
         assert!(matches!(
-            surface.smile_at(0.0),
+            surface.smile_at(Tenor(0.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
         assert!(matches!(
-            surface.smile_at(-1.0),
+            surface.smile_at(Tenor(-1.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -553,7 +554,7 @@ mod tests {
         let s1 = flat_smile(100.0, 1.0, 0.20);
         let surface = PiecewiseSurface::new(vec![1.0], vec![s1]).unwrap();
         assert!(matches!(
-            surface.black_vol(0.0, 100.0),
+            surface.black_vol(Tenor(0.0), Strike(100.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -563,7 +564,7 @@ mod tests {
         let s1 = flat_smile(100.0, 1.0, 0.20);
         let surface = PiecewiseSurface::new(vec![1.0], vec![s1]).unwrap();
         assert!(matches!(
-            surface.black_variance(-0.5, 100.0),
+            surface.black_variance(Tenor(-0.5), Strike(100.0)),
             Err(VolSurfError::InvalidInput { .. })
         ));
     }
@@ -608,7 +609,7 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![t1], vec![s1]).unwrap();
 
         // Query before the only tenor — flat vol extrapolation
-        let v = surface.black_vol(0.1, 100.0).unwrap();
+        let v = surface.black_vol(Tenor(0.1), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(v.0, vol, epsilon = 1e-10);
     }
 
@@ -620,7 +621,7 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![t1], vec![s1]).unwrap();
 
         // Query after the only tenor — flat vol extrapolation
-        let v = surface.black_vol(2.0, 100.0).unwrap();
+        let v = surface.black_vol(Tenor(2.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(v.0, vol, epsilon = 1e-10);
     }
 
@@ -631,9 +632,9 @@ mod tests {
         let s1 = flat_smile(100.0, t1, vol);
         let surface = PiecewiseSurface::new(vec![t1], vec![s1]).unwrap();
 
-        let smile = surface.smile_at(0.5).unwrap();
+        let smile = surface.smile_at(Tenor(0.5)).unwrap();
         assert_abs_diff_eq!(smile.expiry(), 0.5, epsilon = 1e-14);
-        let v = smile.vol(100.0).unwrap();
+        let v = smile.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(v.0, vol, epsilon = 1e-4);
     }
 
@@ -644,9 +645,9 @@ mod tests {
         let s1 = flat_smile(100.0, t1, vol);
         let surface = PiecewiseSurface::new(vec![t1], vec![s1]).unwrap();
 
-        let smile = surface.smile_at(2.0).unwrap();
+        let smile = surface.smile_at(Tenor(2.0)).unwrap();
         assert_abs_diff_eq!(smile.expiry(), 2.0, epsilon = 1e-14);
-        let v = smile.vol(100.0).unwrap();
+        let v = smile.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(v.0, vol, epsilon = 1e-4);
     }
 
@@ -659,7 +660,9 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![0.25, 1.0], vec![s1, s2]).unwrap();
 
         // Query at T = 0.25 + 1e-11 (within 1e-10 tolerance) — should match exactly
-        let vol = surface.black_vol(0.25 + 1e-11, 100.0).unwrap();
+        let vol = surface
+            .black_vol(Tenor(0.25 + 1e-11), Strike(100.0))
+            .unwrap();
         assert_abs_diff_eq!(vol.0, 0.20, epsilon = 1e-10);
     }
 
@@ -670,7 +673,9 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![0.25, 1.0], vec![s1, s2]).unwrap();
 
         // Query at T = 0.25 + 1e-8 (outside 1e-10 tolerance) — should interpolate
-        let vol = surface.black_vol(0.25 + 1e-8, 100.0).unwrap();
+        let vol = surface
+            .black_vol(Tenor(0.25 + 1e-8), Strike(100.0))
+            .unwrap();
         // This is very close to T=0.25, so vol should still be very close to 0.20
         // but technically goes through the interpolation path
         assert!(vol.0 > 0.0);
@@ -690,14 +695,14 @@ mod tests {
         let w1 = 0.18 * 0.18 * 0.25;
         let w2 = 0.20 * 0.20 * 0.5;
         let expected = 0.5 * w1 + 0.5 * w2;
-        let var = surface.black_variance(0.375, 100.0).unwrap();
+        let var = surface.black_variance(Tenor(0.375), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(var.0, expected, epsilon = 1e-10);
 
         // Between second and third tenor (T=0.75, alpha=0.5)
         let w2b = 0.20 * 0.20 * 0.5;
         let w3 = 0.25 * 0.25 * 1.0;
         let expected2 = 0.5 * w2b + 0.5 * w3;
-        let var2 = surface.black_variance(0.75, 100.0).unwrap();
+        let var2 = surface.black_variance(Tenor(0.75), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(var2.0, expected2, epsilon = 1e-10);
     }
 
@@ -708,7 +713,7 @@ mod tests {
         let s2 = flat_smile(400.0, 1.0, 0.20);
         let surface = PiecewiseSurface::new(vec![0.5, 1.0], vec![s1, s2]).unwrap();
 
-        let smile = surface.smile_at(0.75).unwrap();
+        let smile = surface.smile_at(Tenor(0.75)).unwrap();
         let expected_fwd = (100.0_f64.ln() * 0.5 + 400.0_f64.ln() * 0.5).exp();
         assert_abs_diff_eq!(smile.forward(), expected_fwd, epsilon = 1e-10);
         assert_abs_diff_eq!(expected_fwd, 200.0, epsilon = 1e-10);
@@ -721,10 +726,10 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![0.5, 1.0], vec![s1, s2]).unwrap();
 
         let t = 0.75;
-        let smile = surface.smile_at(t).unwrap();
+        let smile = surface.smile_at(Tenor(t)).unwrap();
         for &k in &[95.0, 100.0, 105.0] {
-            let from_smile = smile.variance(k).unwrap().0;
-            let from_surface = surface.black_variance(t, k).unwrap().0;
+            let from_smile = smile.variance(Strike(k)).unwrap().0;
+            let from_surface = surface.black_variance(Tenor(t), Strike(k)).unwrap().0;
             assert_abs_diff_eq!(from_smile, from_surface, epsilon = 1e-3);
         }
     }
@@ -737,7 +742,7 @@ mod tests {
         for &bad_strike in &[0.0, -100.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             assert!(
                 matches!(
-                    surface.black_variance(0.5, bad_strike),
+                    surface.black_variance(Tenor(0.5), Strike(bad_strike)),
                     Err(VolSurfError::InvalidInput { .. })
                 ),
                 "should reject strike={bad_strike}"

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -36,7 +36,7 @@ use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
 use crate::surface::CALENDAR_ARB_TOL;
 use crate::surface::VolSurface;
 use crate::surface::arbitrage::{CalendarViolation, SurfaceDiagnostics};
-use crate::types::{Variance, Vol};
+use crate::types::{Strike, Tenor, Variance, Vol};
 use crate::validate::validate_positive;
 
 /// SSVI volatility surface parameterized by Gatheral-Jacquier (2014).
@@ -378,6 +378,7 @@ impl SsviSurface {
     ///
     /// ```
     /// use volsurf::surface::{SsviSurface, VolSurface};
+    /// use volsurf::types::{Strike, Tenor};
     ///
     /// let data_3m = vec![
     ///     (80.0, 0.30), (90.0, 0.25), (95.0, 0.23),
@@ -392,7 +393,7 @@ impl SsviSurface {
     ///     &[0.25, 1.0],
     ///     &[100.0, 100.0],
     /// )?;
-    /// let vol = surface.black_vol(0.5, 100.0)?;
+    /// let vol = surface.black_vol(Tenor(0.5), Strike(100.0))?;
     /// assert!(vol.0 > 0.0);
     /// # Ok::<(), volsurf::VolSurfError>(())
     /// ```
@@ -457,7 +458,7 @@ impl SsviSurface {
                     rms_error: None,
                 })?;
             // Extract ATM total variance (theta) from calibrated SVI
-            let theta = svi.variance(forwards[i])?.0;
+            let theta = svi.variance(Strike(forwards[i]))?.0;
             thetas.push(theta);
             rho_sum += svi.rho();
         }
@@ -597,17 +598,17 @@ impl SsviSurface {
 pub(crate) const CALENDAR_CHECK_GRID_SIZE: usize = 41;
 
 impl VolSurface for SsviSurface {
-    fn black_vol(&self, expiry: f64, strike: f64) -> error::Result<Vol> {
-        validate_positive(expiry, "expiry")?;
+    fn black_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol> {
+        validate_positive(expiry.0, "expiry")?;
         let var = self.black_variance(expiry, strike)?;
-        Ok(Vol((var.0 / expiry).sqrt()))
+        Ok(Vol((var.0 / expiry.0).sqrt()))
     }
 
-    fn black_variance(&self, expiry: f64, strike: f64) -> error::Result<Variance> {
-        validate_positive(expiry, "expiry")?;
-        validate_positive(strike, "strike")?;
-        let (theta, forward) = self.theta_and_forward_at(expiry);
-        let k = (strike / forward).ln();
+    fn black_variance(&self, expiry: Tenor, strike: Strike) -> error::Result<Variance> {
+        validate_positive(expiry.0, "expiry")?;
+        validate_positive(strike.0, "strike")?;
+        let (theta, forward) = self.theta_and_forward_at(expiry.0);
+        let k = (strike.0 / forward).ln();
         let w = self.total_variance_at(theta, k);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -617,10 +618,10 @@ impl VolSurface for SsviSurface {
         Ok(Variance(w))
     }
 
-    fn smile_at(&self, expiry: f64) -> error::Result<Box<dyn SmileSection>> {
-        validate_positive(expiry, "expiry")?;
-        let (theta, forward) = self.theta_and_forward_at(expiry);
-        let slice = SsviSlice::new(forward, expiry, self.rho, self.eta, self.gamma, theta)?;
+    fn smile_at(&self, expiry: Tenor) -> error::Result<Box<dyn SmileSection>> {
+        validate_positive(expiry.0, "expiry")?;
+        let (theta, forward) = self.theta_and_forward_at(expiry.0);
+        let slice = SsviSlice::new(forward, expiry.0, self.rho, self.eta, self.gamma, theta)?;
         Ok(Box::new(slice))
     }
 
@@ -774,11 +775,11 @@ impl SsviSlice {
     ///
     /// ```
     /// use volsurf::surface::SsviSlice;
-    /// use volsurf::SmileSection;
+    /// use volsurf::{SmileSection, Strike};
     ///
     /// // 20% ATM vol at 1Y: theta = 0.20^2 * 1.0 = 0.04
     /// let slice = SsviSlice::new(100.0, 1.0, -0.3, 0.5, 0.5, 0.04)?;
-    /// let vol = slice.vol(100.0)?;
+    /// let vol = slice.vol(Strike(100.0))?;
     /// assert!((vol.0 - 0.20).abs() < 0.01);
     /// # Ok::<(), volsurf::VolSurfError>(())
     /// ```
@@ -879,9 +880,9 @@ impl SsviSlice {
 }
 
 impl SmileSection for SsviSlice {
-    fn vol(&self, strike: f64) -> error::Result<Vol> {
-        validate_positive(strike, "strike")?;
-        let k = (strike / self.forward).ln();
+    fn vol(&self, strike: Strike) -> error::Result<Vol> {
+        validate_positive(strike.0, "strike")?;
+        let k = (strike.0 / self.forward).ln();
         let w = self.total_variance(k);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -891,9 +892,9 @@ impl SmileSection for SsviSlice {
         Ok(Vol((w / self.expiry).sqrt()))
     }
 
-    fn variance(&self, strike: f64) -> error::Result<Variance> {
-        validate_positive(strike, "strike")?;
-        let k = (strike / self.forward).ln();
+    fn variance(&self, strike: Strike) -> error::Result<Variance> {
+        validate_positive(strike.0, "strike")?;
+        let k = (strike.0 / self.forward).ln();
         let w = self.total_variance(k);
         if w < 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -921,9 +922,9 @@ impl SmileSection for SsviSlice {
     ///
     /// # Reference
     /// Breeden & Litzenberger (1978); Gatheral & Jacquier (2014), §4.
-    fn density(&self, strike: f64) -> error::Result<f64> {
-        validate_positive(strike, "strike")?;
-        let k = (strike / self.forward).ln();
+    fn density(&self, strike: Strike) -> error::Result<f64> {
+        validate_positive(strike.0, "strike")?;
+        let k = (strike.0 / self.forward).ln();
         let w = self.total_variance(k);
         if w <= 0.0 {
             return Err(VolSurfError::NumericalError {
@@ -934,7 +935,7 @@ impl SmileSection for SsviSlice {
         let sqrt_w = w.sqrt();
         let d2 = -k / sqrt_w - sqrt_w / 2.0;
         let n_d2 = (-d2 * d2 / 2.0).exp() / (2.0 * PI).sqrt();
-        Ok(g * n_d2 / (strike * sqrt_w))
+        Ok(g * n_d2 / (strike.0 * sqrt_w))
     }
 
     /// Check butterfly arbitrage by scanning the Gatheral g-function.
@@ -959,7 +960,7 @@ impl SmileSection for SsviSlice {
             let g = self.g_function(k);
             if g < -crate::smile::BUTTERFLY_G_TOL {
                 let strike = self.forward * k.exp();
-                let d = match self.density(strike) {
+                let d = match self.density(Strike(strike)) {
                     Ok(d) => d,
                     Err(_) => continue,
                 };
@@ -1515,7 +1516,7 @@ mod tests {
             .map(|(&t, strikes)| {
                 strikes
                     .iter()
-                    .map(|&k| (k, surface.black_vol(t, k).unwrap().0))
+                    .map(|&k| (k, surface.black_vol(Tenor(t), Strike(k)).unwrap().0))
                     .collect()
             })
             .collect()
@@ -1539,7 +1540,7 @@ mod tests {
         let mut n_points = 0;
         for (i, &t) in tenors.iter().enumerate() {
             for &(strike, vol_obs) in &market_data[i] {
-                let vol_fit = calibrated.black_vol(t, strike).unwrap().0;
+                let vol_fit = calibrated.black_vol(Tenor(t), Strike(strike)).unwrap().0;
                 total_rss += (vol_fit - vol_obs).powi(2);
                 n_points += 1;
             }
@@ -1574,7 +1575,7 @@ mod tests {
         let mut n_points = 0;
         for (i, &t) in tenors.iter().enumerate() {
             for &(strike, vol_obs) in &market_data[i] {
-                let vol_fit = calibrated.black_vol(t, strike).unwrap().0;
+                let vol_fit = calibrated.black_vol(Tenor(t), Strike(strike)).unwrap().0;
                 total_rss += (vol_fit - vol_obs).powi(2);
                 n_points += 1;
             }
@@ -1612,7 +1613,7 @@ mod tests {
         let mut n_points = 0;
         for (i, &t) in tenors.iter().enumerate() {
             for &(strike, vol_obs) in &market_data[i] {
-                let vol_fit = calibrated.black_vol(t, strike).unwrap().0;
+                let vol_fit = calibrated.black_vol(Tenor(t), Strike(strike)).unwrap().0;
                 total_rss += (vol_fit - vol_obs).powi(2);
                 n_points += 1;
             }
@@ -1873,7 +1874,7 @@ mod tests {
         let s = equity_surface();
         // At T=1.0, K=100 (ATM), theta=0.16.
         // vol = sqrt(theta / T) = sqrt(0.16) = 0.4
-        let vol = s.black_vol(1.0, 100.0).unwrap();
+        let vol = s.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.4, epsilon = 1e-10);
     }
 
@@ -1881,7 +1882,7 @@ mod tests {
     fn black_variance_at_stored_tenor() {
         let s = equity_surface();
         // At T=1.0, K=100 (ATM), variance = theta = 0.16
-        let var = s.black_variance(1.0, 100.0).unwrap();
+        let var = s.black_variance(Tenor(1.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(var.0, 0.16, epsilon = 1e-14);
     }
 
@@ -1891,8 +1892,8 @@ mod tests {
         let s = equity_surface();
         for &expiry in &[0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0] {
             for &strike in &[80.0, 100.0, 120.0] {
-                let vol = s.black_vol(expiry, strike).unwrap();
-                let var = s.black_variance(expiry, strike).unwrap();
+                let vol = s.black_vol(Tenor(expiry), Strike(strike)).unwrap();
+                let var = s.black_variance(Tenor(expiry), Strike(strike)).unwrap();
                 assert_abs_diff_eq!(vol.0 * vol.0 * expiry, var.0, epsilon = 1e-12);
             }
         }
@@ -1903,7 +1904,7 @@ mod tests {
         let s = equity_surface();
         // At T=0.75 (between T=0.5 and T=1.0), the interpolated theta = 0.12.
         // ATM vol = sqrt(0.12 / 0.75) = sqrt(0.16) = 0.4
-        let vol = s.black_vol(0.75, 100.0).unwrap();
+        let vol = s.black_vol(Tenor(0.75), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.4, epsilon = 1e-10);
     }
 
@@ -1912,7 +1913,7 @@ mod tests {
         let s = equity_surface();
         // T=0.1 < T_0=0.25. Flat vol: theta(0.1) = 0.04 * 0.1/0.25 = 0.016.
         // ATM vol = sqrt(0.016 / 0.1) = sqrt(0.16) = 0.4
-        let vol = s.black_vol(0.1, 100.0).unwrap();
+        let vol = s.black_vol(Tenor(0.1), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.4, epsilon = 1e-10);
     }
 
@@ -1921,38 +1922,36 @@ mod tests {
         let s = equity_surface();
         // T=3.0 > T_n=2.0. Flat vol: theta(3.0) = 0.32 * 3.0/2.0 = 0.48.
         // ATM vol = sqrt(0.48 / 3.0) = sqrt(0.16) = 0.4
-        let vol = s.black_vol(3.0, 100.0).unwrap();
+        let vol = s.black_vol(Tenor(3.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.4, epsilon = 1e-10);
     }
 
     #[test]
     fn black_vol_rejects_invalid_inputs() {
         let s = equity_surface();
-        assert!(s.black_vol(0.0, 100.0).is_err());
-        assert!(s.black_vol(-1.0, 100.0).is_err());
-        assert!(s.black_vol(1.0, 0.0).is_err());
-        assert!(s.black_vol(1.0, -100.0).is_err());
+        assert!(s.black_vol(Tenor(0.0), Strike(100.0)).is_err());
+        assert!(s.black_vol(Tenor(-1.0), Strike(100.0)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(0.0)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(-100.0)).is_err());
     }
 
     #[test]
     fn smile_at_returns_working_section() {
         let s = equity_surface();
-        let smile = s.smile_at(1.0).unwrap();
+        let smile = s.smile_at(Tenor(1.0)).unwrap();
         assert_eq!(smile.forward(), 100.0);
         assert_eq!(smile.expiry(), 1.0);
-        // ATM vol via smile should match surface query
-        let smile_vol = smile.vol(100.0).unwrap();
-        let surface_vol = s.black_vol(1.0, 100.0).unwrap();
+        let smile_vol = smile.vol(Strike(100.0)).unwrap();
+        let surface_vol = s.black_vol(Tenor(1.0), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(smile_vol.0, surface_vol.0, epsilon = 1e-14);
     }
 
     #[test]
     fn smile_at_interpolated_tenor() {
         let s = equity_surface();
-        let smile = s.smile_at(0.75).unwrap();
-        // ATM variance from smile should match surface
-        let smile_var = smile.variance(100.0).unwrap();
-        let surface_var = s.black_variance(0.75, 100.0).unwrap();
+        let smile = s.smile_at(Tenor(0.75)).unwrap();
+        let smile_var = smile.variance(Strike(100.0)).unwrap();
+        let surface_var = s.black_variance(Tenor(0.75), Strike(100.0)).unwrap();
         assert_abs_diff_eq!(smile_var.0, surface_var.0, epsilon = 1e-14);
     }
 
@@ -1960,10 +1959,10 @@ mod tests {
     fn smile_at_agrees_with_surface_otm() {
         // OTM strikes via smile should match direct surface query.
         let s = equity_surface();
-        let smile = s.smile_at(1.0).unwrap();
+        let smile = s.smile_at(Tenor(1.0)).unwrap();
         for &strike in &[80.0, 90.0, 110.0, 120.0] {
-            let smile_vol = smile.vol(strike).unwrap();
-            let surface_vol = s.black_vol(1.0, strike).unwrap();
+            let smile_vol = smile.vol(Strike(strike)).unwrap();
+            let surface_vol = s.black_vol(Tenor(1.0), Strike(strike)).unwrap();
             assert_abs_diff_eq!(smile_vol.0, surface_vol.0, epsilon = 1e-14);
         }
     }
@@ -2232,15 +2231,14 @@ mod tests {
         // ATM: strike = forward. k = 0. w(0) = theta.
         // vol = sqrt(theta / T) = sqrt(0.16 / 1.0) = 0.4
         let s = equity_slice();
-        let vol = s.vol(100.0).unwrap();
+        let vol = s.vol(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(vol.0, 0.4, epsilon = 1e-10);
     }
 
     #[test]
     fn slice_variance_atm_equals_theta() {
-        // At ATM: variance = theta exactly.
         let s = equity_slice();
-        let var = s.variance(100.0).unwrap();
+        let var = s.variance(Strike(100.0)).unwrap();
         assert_abs_diff_eq!(var.0, 0.16, epsilon = 1e-14);
     }
 
@@ -2249,8 +2247,8 @@ mod tests {
         // variance(K) == vol(K)^2 * T for any strike.
         let s = equity_slice();
         for &strike in &[80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = s.vol(strike).unwrap();
-            let var = s.variance(strike).unwrap();
+            let vol = s.vol(Strike(strike)).unwrap();
+            let var = s.variance(Strike(strike)).unwrap();
             assert_abs_diff_eq!(var.0, vol.0 * vol.0 * s.expiry(), epsilon = 1e-14);
         }
     }
@@ -2265,7 +2263,7 @@ mod tests {
         for &strike in &[80.0, 90.0, 100.0, 110.0, 120.0] {
             let k = (strike / 100.0_f64).ln();
             let w_surface = surface.total_variance_at(theta, k);
-            let w_slice = slice.variance(strike).unwrap().0;
+            let w_slice = slice.variance(Strike(strike)).unwrap().0;
             assert_abs_diff_eq!(w_surface, w_slice, epsilon = 1e-14);
         }
     }
@@ -2273,18 +2271,18 @@ mod tests {
     #[test]
     fn slice_vol_rejects_non_positive_strikes() {
         let s = equity_slice();
-        assert!(s.vol(0.0).is_err());
-        assert!(s.vol(-100.0).is_err());
-        assert!(s.variance(0.0).is_err());
-        assert!(s.variance(-100.0).is_err());
+        assert!(s.vol(Strike(0.0)).is_err());
+        assert!(s.vol(Strike(-100.0)).is_err());
+        assert!(s.variance(Strike(0.0)).is_err());
+        assert!(s.variance(Strike(-100.0)).is_err());
     }
 
     #[test]
     fn slice_skew_direction() {
         // rho < 0: OTM puts have higher vol than OTM calls.
         let s = equity_slice();
-        let vol_put = s.vol(80.0).unwrap().0;
-        let vol_call = s.vol(120.0).unwrap().0;
+        let vol_put = s.vol(Strike(80.0)).unwrap().0;
+        let vol_call = s.vol(Strike(120.0)).unwrap().0;
         assert!(vol_put > vol_call, "negative rho should produce put skew");
     }
 
@@ -2293,7 +2291,7 @@ mod tests {
         // density should be positive near ATM for well-behaved params.
         let s = equity_slice();
         for &strike in &[90.0, 95.0, 100.0, 105.0, 110.0] {
-            let d = s.density(strike).unwrap();
+            let d = s.density(Strike(strike)).unwrap();
             assert!(d > 0.0, "density({strike}) = {d} should be positive");
         }
     }
@@ -2328,7 +2326,7 @@ mod tests {
         let report = s.is_arbitrage_free().unwrap();
         assert!(!report.butterfly_violations.is_empty());
         for v in &report.butterfly_violations {
-            let expected = s.density(v.strike).unwrap();
+            let expected = s.density(Strike(v.strike)).unwrap();
             assert_abs_diff_eq!(v.density, expected, epsilon = 1e-14);
             assert_abs_diff_eq!(v.magnitude, expected.abs(), epsilon = 1e-14);
         }
@@ -2345,14 +2343,14 @@ mod tests {
 
         for &strike in &[80.0, 100.0, 120.0] {
             let h = strike * 1e-4;
-            let vol_m = s.vol(strike - h).unwrap().0;
-            let vol_0 = s.vol(strike).unwrap().0;
-            let vol_p = s.vol(strike + h).unwrap().0;
+            let vol_m = s.vol(Strike(strike - h)).unwrap().0;
+            let vol_0 = s.vol(Strike(strike)).unwrap().0;
+            let vol_p = s.vol(Strike(strike + h)).unwrap().0;
             let c_m = black_price(f, strike - h, vol_m, t, OptionType::Call).unwrap();
             let c_0 = black_price(f, strike, vol_0, t, OptionType::Call).unwrap();
             let c_p = black_price(f, strike + h, vol_p, t, OptionType::Call).unwrap();
             let numerical = (c_p - 2.0 * c_0 + c_m) / (h * h);
-            let analytical = s.density(strike).unwrap();
+            let analytical = s.density(Strike(strike)).unwrap();
             assert_abs_diff_eq!(analytical, numerical, epsilon = 1e-4);
         }
     }
@@ -2373,8 +2371,8 @@ mod tests {
         assert_eq!(s.theta(), s2.theta());
         // Verify vol agrees after deserialization
         assert_abs_diff_eq!(
-            s.vol(100.0).unwrap().0,
-            s2.vol(100.0).unwrap().0,
+            s.vol(Strike(100.0)).unwrap().0,
+            s2.vol(Strike(100.0)).unwrap().0,
             epsilon = 1e-14
         );
     }

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -1936,6 +1936,27 @@ mod tests {
     }
 
     #[test]
+    fn black_vol_rejects_nan_inputs() {
+        let s = equity_surface();
+        assert!(s.black_vol(Tenor(f64::NAN), Strike(100.0)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(f64::NAN)).is_err());
+        assert!(s.black_variance(Tenor(f64::NAN), Strike(100.0)).is_err());
+    }
+
+    #[test]
+    fn black_vol_rejects_inf_inputs() {
+        let s = equity_surface();
+        assert!(s.black_vol(Tenor(f64::INFINITY), Strike(100.0)).is_err());
+        assert!(
+            s.black_vol(Tenor(f64::NEG_INFINITY), Strike(100.0))
+                .is_err()
+        );
+        assert!(s.black_vol(Tenor(1.0), Strike(f64::INFINITY)).is_err());
+        assert!(s.black_vol(Tenor(1.0), Strike(f64::NEG_INFINITY)).is_err());
+        assert!(s.smile_at(Tenor(f64::INFINITY)).is_err());
+    }
+
+    #[test]
     fn smile_at_returns_working_section() {
         let s = equity_surface();
         let smile = s.smile_at(Tenor(1.0)).unwrap();
@@ -2275,6 +2296,21 @@ mod tests {
         assert!(s.vol(Strike(-100.0)).is_err());
         assert!(s.variance(Strike(0.0)).is_err());
         assert!(s.variance(Strike(-100.0)).is_err());
+    }
+
+    #[test]
+    fn slice_vol_rejects_nan_strike() {
+        let s = equity_slice();
+        assert!(s.vol(Strike(f64::NAN)).is_err());
+        assert!(s.variance(Strike(f64::NAN)).is_err());
+    }
+
+    #[test]
+    fn slice_vol_rejects_inf_strike() {
+        let s = equity_slice();
+        assert!(s.vol(Strike(f64::INFINITY)).is_err());
+        assert!(s.vol(Strike(f64::NEG_INFINITY)).is_err());
+        assert!(s.variance(Strike(f64::INFINITY)).is_err());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,14 +5,12 @@
 //!
 //! # Newtype Strategy
 //!
-//! **Outputs use newtypes** — [`Vol`], [`Variance`], [`Strike`], [`Tenor`] wrap
-//! return values so callers can't accidentally mix a volatility with a variance.
-//!
-//! **Inputs use bare `f64`** — API methods like `vol(strike: f64)` accept raw
-//! floats for ergonomics. Requiring `vol(Strike(100.0))` at every call site adds
-//! ceremony without meaningful safety (the caller already knows they're passing
-//! a strike). This is a deliberate trade-off: newtypes guard against *silent*
-//! misuse of outputs, while inputs are self-documenting via parameter names.
+//! **Both inputs and outputs use newtypes.** [`Vol`], [`Variance`] wrap return
+//! values so callers can't accidentally mix a volatility with a variance.
+//! [`Strike`] and [`Tenor`] wrap inputs to prevent parameter swapping — e.g.,
+//! `black_vol(Tenor(0.5), Strike(100.0))` cannot be accidentally transposed.
+//! The ceremony of `Strike(100.0)` is a small cost for compile-time safety
+//! at the API boundary.
 //!
 //! # Why no `Eq` or `Ord`?
 //! These types wrap `f64`, which does not implement `Eq` or `Ord` because `NaN`

--- a/tests/dupire_integration.rs
+++ b/tests/dupire_integration.rs
@@ -11,6 +11,7 @@ use volsurf::local_vol::{DupireLocalVol, LocalVol};
 use volsurf::smile::SmileSection;
 use volsurf::smile::spline::SplineSmile;
 use volsurf::surface::{PiecewiseSurface, SsviSurface, VolSurface};
+use volsurf::{Strike, Tenor};
 
 fn ssvi_test_surface() -> Arc<dyn VolSurface> {
     Arc::new(
@@ -40,7 +41,7 @@ fn ssvi_local_vol_grid_positive() {
     for &t in &tenors {
         for &k in &strikes {
             let v = dupire
-                .local_vol(t, k)
+                .local_vol(Tenor(t), Strike(k))
                 .unwrap_or_else(|e| panic!("failed at T={t}, K={k}: {e}"));
             assert!(v.0 > 0.0, "non-positive at T={t}, K={k}: {}", v.0);
             assert!(v.0.is_finite(), "non-finite at T={t}, K={k}: {}", v.0);
@@ -81,7 +82,7 @@ fn calendar_violation_returns_error() {
     let dupire = DupireLocalVol::new(surface);
 
     // At the midpoint, total variance is decreasing → negative dw/dT
-    let result = dupire.local_vol(0.5, 100.0);
+    let result = dupire.local_vol(Tenor(0.5), Strike(100.0));
     assert!(
         result.is_err(),
         "expected error for calendar violation, got {:?}",
@@ -103,7 +104,7 @@ fn deep_otm_no_panic() {
     let dupire = DupireLocalVol::new(surface);
 
     for &k in &[50.0, 200.0] {
-        if let Ok(v) = dupire.local_vol(0.5, k) {
+        if let Ok(v) = dupire.local_vol(Tenor(0.5), Strike(k)) {
             assert!(v.0.is_finite(), "non-finite at K={k}: {}", v.0);
         }
     }
@@ -138,9 +139,9 @@ fn bump_size_convergence() {
     let mut err_fine = 0.0;
 
     for &(t, k) in &points {
-        let v_ref = reference.local_vol(t, k).unwrap().0;
-        let v_coarse = coarse.local_vol(t, k).unwrap().0;
-        let v_fine = fine.local_vol(t, k).unwrap().0;
+        let v_ref = reference.local_vol(Tenor(t), Strike(k)).unwrap().0;
+        let v_coarse = coarse.local_vol(Tenor(t), Strike(k)).unwrap().0;
+        let v_fine = fine.local_vol(Tenor(t), Strike(k)).unwrap().0;
         err_coarse += (v_coarse - v_ref).abs();
         err_fine += (v_fine - v_ref).abs();
     }
@@ -172,7 +173,7 @@ fn thread_safe_local_vol() {
             let d = Arc::clone(&dupire);
             std::thread::spawn(move || {
                 let k = 90.0 + 10.0 * i as f64;
-                d.local_vol(0.5, k).unwrap()
+                d.local_vol(Tenor(0.5), Strike(k)).unwrap()
             })
         })
         .collect();

--- a/tests/hendriks_martini_2019.rs
+++ b/tests/hendriks_martini_2019.rs
@@ -8,8 +8,8 @@
 //!   ρ(θ) = −0.76 − 0.11·(θ/θ_max)^{0.51}  →  ρ₀=−0.76, ρₘ=−0.87, a=0.51
 
 use approx::assert_abs_diff_eq;
-use volsurf::SmileSection;
 use volsurf::surface::{EssviSlice, EssviSurface, SsviSlice, SsviSurface, VolSurface};
+use volsurf::{SmileSection, Strike, Tenor};
 
 const ETA: f64 = 0.98;
 const GAMMA: f64 = 0.42;
@@ -94,7 +94,7 @@ fn eq_2_2_hand_computed_values() {
     let k = 0.2;
     let expected_pos = w_formula(theta, k, rho, eta, gamma);
     let strike_pos = 100.0 * k.exp();
-    let var_pos = slice.variance(strike_pos).unwrap().0;
+    let var_pos = slice.variance(Strike(strike_pos)).unwrap().0;
     assert_abs_diff_eq!(var_pos, expected_pos, epsilon = 1e-14);
     assert_abs_diff_eq!(
         expected_pos,
@@ -106,7 +106,7 @@ fn eq_2_2_hand_computed_values() {
     // w = 0.02[1 + 0.15 + √(0.64 + 0.91)] = 0.02[1.15 + √1.55]
     let expected_neg = w_formula(theta, -k, rho, eta, gamma);
     let strike_neg = 100.0 * (-k).exp();
-    let var_neg = slice.variance(strike_neg).unwrap().0;
+    let var_neg = slice.variance(Strike(strike_neg)).unwrap().0;
     assert_abs_diff_eq!(var_neg, expected_neg, epsilon = 1e-14);
     assert_abs_diff_eq!(
         expected_neg,
@@ -133,7 +133,7 @@ fn eq_2_2_code_matches_formula_across_strikes() {
     for i in -15..=15 {
         let k = i as f64 * 0.1;
         let strike = forward * k.exp();
-        let var_code = slice.variance(strike).unwrap().0;
+        let var_code = slice.variance(Strike(strike)).unwrap().0;
         let var_hand = w_formula(theta, k, rho, eta, gamma);
         assert!(
             (var_code - var_hand).abs() < 1e-13,
@@ -345,8 +345,8 @@ fn ssvi_degeneracy_slice() {
     let ssvi = SsviSlice::new(forward, expiry, rho, eta, gamma, theta).unwrap();
 
     for &strike in &[60.0, 80.0, 90.0, 100.0, 110.0, 120.0, 150.0] {
-        let v_essvi = essvi.vol(strike).unwrap().0;
-        let v_ssvi = ssvi.vol(strike).unwrap().0;
+        let v_essvi = essvi.vol(Strike(strike)).unwrap().0;
+        let v_ssvi = ssvi.vol(Strike(strike)).unwrap().0;
         assert_eq!(
             v_essvi.to_bits(),
             v_ssvi.to_bits(),
@@ -381,8 +381,8 @@ fn ssvi_degeneracy_surface() {
 
     for &t in &tenors {
         for &k in &[70.0, 85.0, 100.0, 115.0, 140.0] {
-            let v_essvi = essvi.black_vol(t, k).unwrap().0;
-            let v_ssvi = ssvi.black_vol(t, k).unwrap().0;
+            let v_essvi = essvi.black_vol(Tenor(t), Strike(k)).unwrap().0;
+            let v_ssvi = ssvi.black_vol(Tenor(t), Strike(k)).unwrap().0;
             assert_eq!(
                 v_essvi.to_bits(),
                 v_ssvi.to_bits(),
@@ -406,7 +406,7 @@ fn paper_surface_total_variance_monotone_in_theta() {
         let mut prev_var = 0.0;
 
         for (i, &t) in tenors.iter().enumerate() {
-            let var = s.black_variance(t, strike).unwrap().0;
+            let var = s.black_variance(Tenor(t), Strike(strike)).unwrap().0;
             assert!(
                 var >= prev_var - 1e-12,
                 "calendar arb at strike={strike:.2}, tenor[{i}]={t}: var={var:.8} < prev={prev_var:.8}"
@@ -429,7 +429,7 @@ fn paper_surface_atm_variance_matches_thetas() {
         .zip(forwards.iter())
         .enumerate()
     {
-        let var = s.black_variance(t, fwd).unwrap().0;
+        let var = s.black_variance(Tenor(t), Strike(fwd)).unwrap().0;
         assert!(
             (var - theta).abs() < 1e-12,
             "ATM variance mismatch at tenor[{i}]={t}: var={var}, theta={theta}"
@@ -451,7 +451,7 @@ fn calibrate_round_trip_paper_params() {
         .zip(strikes.iter())
         .map(|(&t, ks)| {
             ks.iter()
-                .map(|&k| (k, original.black_vol(t, k).unwrap().0))
+                .map(|&k| (k, original.black_vol(Tenor(t), Strike(k)).unwrap().0))
                 .collect()
         })
         .collect();
@@ -462,7 +462,7 @@ fn calibrate_round_trip_paper_params() {
     let mut n = 0;
     for (i, &t) in tenors.iter().enumerate() {
         for &(strike, vol_obs) in &market_data[i] {
-            let vol_fit = calibrated.black_vol(t, strike).unwrap().0;
+            let vol_fit = calibrated.black_vol(Tenor(t), Strike(strike)).unwrap().0;
             total_rss += (vol_fit - vol_obs).powi(2);
             n += 1;
         }
@@ -488,7 +488,7 @@ fn calibrate_paper_structural_check() {
         .zip(strikes.iter())
         .map(|(&t, ks)| {
             ks.iter()
-                .map(|&k| (k, original.black_vol(t, k).unwrap().0))
+                .map(|&k| (k, original.black_vol(Tenor(t), Strike(k)).unwrap().0))
                 .collect()
         })
         .collect();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,10 +8,10 @@ use std::sync::Arc;
 use std::thread;
 
 use approx::assert_abs_diff_eq;
-use volsurf::VolSurfError;
 use volsurf::smile::spline::SplineSmile;
 use volsurf::smile::{SabrSmile, SmileSection, SviSmile};
 use volsurf::surface::{PiecewiseSurface, SmileModel, SsviSurface, SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor, VolSurfError};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,7 +33,7 @@ fn svi_market_data(p: &SviParams, strikes: &[f64]) -> Vec<(f64, f64)> {
     let smile = SviSmile::new(p.forward, p.expiry, p.a, p.b, p.rho, p.m, p.sigma).unwrap();
     strikes
         .iter()
-        .map(|&k| (k, smile.vol(k).unwrap().0))
+        .map(|&k| (k, smile.vol(Strike(k)).unwrap().0))
         .collect()
 }
 
@@ -122,7 +122,7 @@ fn svi_calibration_round_trip() -> Result<(), Box<dyn std::error::Error>> {
 
     let market_data: Vec<(f64, f64)> = strikes
         .iter()
-        .map(|&k| (k, original.vol(k).unwrap().0))
+        .map(|&k| (k, original.vol(Strike(k)).unwrap().0))
         .collect();
 
     let calibrated = SviSmile::calibrate(forward, expiry, &market_data)?;
@@ -130,8 +130,8 @@ fn svi_calibration_round_trip() -> Result<(), Box<dyn std::error::Error>> {
     // Compute RMS error in vol points
     let mut sum_sq = 0.0;
     for &k in &strikes {
-        let orig_vol = original.vol(k)?.0;
-        let calib_vol = calibrated.vol(k)?.0;
+        let orig_vol = original.vol(Strike(k))?.0;
+        let calib_vol = calibrated.vol(Strike(k))?.0;
         let diff = orig_vol - calib_vol;
         sum_sq += diff * diff;
     }
@@ -154,14 +154,14 @@ fn svi_calibration_round_trip_symmetric() -> Result<(), Box<dyn std::error::Erro
     let original = SviSmile::new(forward, expiry, a, b, rho, m, sigma)?;
     let market_data: Vec<(f64, f64)> = strikes
         .iter()
-        .map(|&k| (k, original.vol(k).unwrap().0))
+        .map(|&k| (k, original.vol(Strike(k)).unwrap().0))
         .collect();
 
     let calibrated = SviSmile::calibrate(forward, expiry, &market_data)?;
 
     let mut sum_sq = 0.0;
     for &k in &strikes {
-        let diff = original.vol(k)?.0 - calibrated.vol(k)?.0;
+        let diff = original.vol(Strike(k))?.0 - calibrated.vol(Strike(k))?.0;
         sum_sq += diff * diff;
     }
     let rms = (sum_sq / strikes.len() as f64).sqrt();
@@ -183,7 +183,7 @@ fn three_tenor_surface_build_and_query() -> Result<(), Box<dyn std::error::Error
 
     // Query at exact tenors — should return reasonable vols
     for t in [0.25, 0.50, 1.00] {
-        let vol = surface.black_vol(t, 100.0)?;
+        let vol = surface.black_vol(Tenor(t), Strike(100.0))?;
         assert!(
             vol.0 > 0.10 && vol.0 < 0.50,
             "ATM vol at T={t} = {:.4}, out of range",
@@ -192,7 +192,7 @@ fn three_tenor_surface_build_and_query() -> Result<(), Box<dyn std::error::Error
     }
 
     // Query between tenors
-    let vol_mid = surface.black_vol(0.375, 100.0)?;
+    let vol_mid = surface.black_vol(Tenor(0.375), Strike(100.0))?;
     assert!(
         vol_mid.0 > 0.10 && vol_mid.0 < 0.50,
         "Interpolated ATM vol = {:.4}, out of range",
@@ -208,8 +208,8 @@ fn three_tenor_vol_variance_consistency() -> Result<(), Box<dyn std::error::Erro
 
     for t in [0.25, 0.375, 0.50, 0.75, 1.00] {
         for k in [80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = surface.black_vol(t, k)?;
-            let var = surface.black_variance(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
+            let var = surface.black_variance(Tenor(t), Strike(k))?;
             assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-10);
         }
     }
@@ -222,11 +222,11 @@ fn three_tenor_smile_at_returns_queryable_section() -> Result<(), Box<dyn std::e
     let surface = build_3_tenor_surface();
 
     for t in [0.25, 0.50, 0.75, 1.00] {
-        let smile = surface.smile_at(t)?;
+        let smile = surface.smile_at(Tenor(t))?;
         assert_abs_diff_eq!(smile.expiry(), t, epsilon = 1e-14);
         assert!(smile.forward() > 0.0);
 
-        let vol = smile.vol(100.0)?;
+        let vol = smile.vol(Strike(100.0))?;
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
     }
 
@@ -247,7 +247,7 @@ fn spx_like_surface_no_nan_no_negative_vol() -> Result<(), Box<dyn std::error::E
 
     for &t in &tenors {
         for &k in &strikes {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             assert!(
                 vol.0.is_finite() && vol.0 > 0.0,
                 "vol({t}, {k}) = {:.6} is invalid",
@@ -268,7 +268,7 @@ fn variance_monotone_in_time_for_arb_free_surface() -> Result<(), Box<dyn std::e
     for &k in &[80.0, 90.0, 100.0, 110.0, 120.0] {
         let mut prev_var = 0.0_f64;
         for &t in &tenors {
-            let var = surface.black_variance(t, k)?.0;
+            let var = surface.black_variance(Tenor(t), Strike(k))?.0;
             assert!(
                 var >= prev_var - 1e-10,
                 "Calendar violation at K={k}: w({t}) = {var:.6} < w(prev) = {prev_var:.6}"
@@ -433,13 +433,13 @@ fn concurrent_surface_queries() -> Result<(), Box<dyn std::error::Error>> {
             thread::spawn(move || -> volsurf::Result<()> {
                 let strike = 80.0 + i as f64 * 5.0;
                 for &t in &[0.25, 0.50, 0.75, 1.00] {
-                    let vol = s.black_vol(t, strike)?;
+                    let vol = s.black_vol(Tenor(t), Strike(strike))?;
                     assert!(
                         vol.0 > 0.0 && vol.0 < 2.0,
                         "vol({t}, {strike}) = {:.4} out of range",
                         vol.0
                     );
-                    let var = s.black_variance(t, strike)?;
+                    let var = s.black_variance(Tenor(t), Strike(strike))?;
                     assert!(var.0 > 0.0 && var.0.is_finite());
                 }
                 Ok(())
@@ -463,8 +463,8 @@ fn concurrent_smile_at_queries() -> Result<(), Box<dyn std::error::Error>> {
             let s = Arc::clone(&surface);
             thread::spawn(move || -> volsurf::Result<()> {
                 let t = 0.25 + i as f64 * 0.25;
-                let smile = s.smile_at(t)?;
-                let vol = smile.vol(100.0)?;
+                let smile = s.smile_at(Tenor(t))?;
+                let vol = smile.vol(Strike(100.0))?;
                 assert!(vol.0 > 0.0);
                 Ok(())
             })
@@ -529,7 +529,7 @@ fn cubic_spline_surface_end_to_end() -> Result<(), Box<dyn std::error::Error>> {
 
     // Query at exact tenors
     for t in [0.25, 1.0] {
-        let vol = surface.black_vol(t, 100.0)?;
+        let vol = surface.black_vol(Tenor(t), Strike(100.0))?;
         assert!(
             vol.0 > 0.10 && vol.0 < 0.50,
             "ATM vol at T={t} = {:.4}, out of range",
@@ -538,7 +538,7 @@ fn cubic_spline_surface_end_to_end() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Interpolated tenor
-    let vol_mid = surface.black_vol(0.5, 100.0)?;
+    let vol_mid = surface.black_vol(Tenor(0.5), Strike(100.0))?;
     assert!(
         vol_mid.0 > 0.10 && vol_mid.0 < 0.50,
         "Interpolated ATM vol = {:.4}, out of range",
@@ -548,20 +548,20 @@ fn cubic_spline_surface_end_to_end() -> Result<(), Box<dyn std::error::Error>> {
     // Vol/variance consistency
     for t in [0.25, 0.5, 1.0] {
         for k in [80.0, 100.0, 120.0] {
-            let vol = surface.black_vol(t, k)?;
-            let var = surface.black_variance(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
+            let var = surface.black_variance(Tenor(t), Strike(k))?;
             assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-10);
         }
     }
 
     // smile_at returns a queryable section
-    let smile = surface.smile_at(0.5)?;
-    assert!(smile.vol(100.0)?.0 > 0.0);
+    let smile = surface.smile_at(Tenor(0.5))?;
+    assert!(smile.vol(Strike(100.0))?.0 > 0.0);
 
     // No NaN across grid
     for t in [0.1, 0.25, 0.5, 0.75, 1.0, 1.5] {
         for &k in &strikes_3m {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             assert!(
                 vol.0.is_finite() && vol.0 > 0.0,
                 "vol({t}, {k}) = {:.6} is invalid",
@@ -624,7 +624,7 @@ fn sabr_market_data(p: &SabrParams, strikes: &[f64]) -> Vec<(f64, f64)> {
     let smile = SabrSmile::new(p.forward, p.expiry, p.alpha, p.beta, p.rho, p.nu).unwrap();
     strikes
         .iter()
-        .map(|&k| (k, smile.vol(k).unwrap().0))
+        .map(|&k| (k, smile.vol(Strike(k)).unwrap().0))
         .collect()
 }
 
@@ -694,7 +694,7 @@ fn sabr_calibration_round_trip() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut sum_sq = 0.0;
     for &(k, v_orig) in &market_data {
-        let v_calib = calibrated.vol(k)?.0;
+        let v_calib = calibrated.vol(Strike(k))?.0;
         let diff = v_orig - v_calib;
         sum_sq += diff * diff;
     }
@@ -726,7 +726,7 @@ fn sabr_calibration_round_trip_lognormal() -> Result<(), Box<dyn std::error::Err
 
     let mut sum_sq = 0.0;
     for &(k, v_orig) in &market_data {
-        let v_calib = calibrated.vol(k)?.0;
+        let v_calib = calibrated.vol(Strike(k))?.0;
         let diff = v_orig - v_calib;
         sum_sq += diff * diff;
     }
@@ -749,7 +749,7 @@ fn sabr_surface_build_and_query() -> Result<(), Box<dyn std::error::Error>> {
 
     // Query at exact tenors — should return reasonable vols
     for t in [0.25, 0.50, 1.00] {
-        let vol = surface.black_vol(t, 100.0)?;
+        let vol = surface.black_vol(Tenor(t), Strike(100.0))?;
         assert!(
             vol.0 > 0.10 && vol.0 < 0.50,
             "SABR ATM vol at T={t} = {:.4}, out of range",
@@ -758,7 +758,7 @@ fn sabr_surface_build_and_query() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Interpolated tenor
-    let vol_mid = surface.black_vol(0.375, 100.0)?;
+    let vol_mid = surface.black_vol(Tenor(0.375), Strike(100.0))?;
     assert!(
         vol_mid.0 > 0.10 && vol_mid.0 < 0.50,
         "SABR interpolated ATM vol = {:.4}, out of range",
@@ -774,8 +774,8 @@ fn sabr_surface_vol_variance_consistency() -> Result<(), Box<dyn std::error::Err
 
     for t in [0.25, 0.375, 0.50, 0.75, 1.00] {
         for k in [80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = surface.black_vol(t, k)?;
-            let var = surface.black_variance(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
+            let var = surface.black_variance(Tenor(t), Strike(k))?;
             assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-10);
         }
     }
@@ -788,10 +788,10 @@ fn sabr_surface_smile_at() -> Result<(), Box<dyn std::error::Error>> {
     let surface = build_sabr_surface();
 
     for t in [0.25, 0.50, 0.75, 1.00] {
-        let smile = surface.smile_at(t)?;
+        let smile = surface.smile_at(Tenor(t))?;
         assert_abs_diff_eq!(smile.expiry(), t, epsilon = 1e-14);
         assert!(smile.forward() > 0.0);
-        let vol = smile.vol(100.0)?;
+        let vol = smile.vol(Strike(100.0))?;
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
     }
 
@@ -806,7 +806,7 @@ fn sabr_surface_no_nan_full_grid() -> Result<(), Box<dyn std::error::Error>> {
 
     for &t in &tenors {
         for &k in &strikes {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             assert!(
                 vol.0.is_finite() && vol.0 > 0.0,
                 "SABR vol({t}, {k}) = {:.6} is invalid",
@@ -840,7 +840,7 @@ fn ssvi_surface_build_and_query() -> Result<(), Box<dyn std::error::Error>> {
     let surface = build_ssvi_surface();
 
     for t in [0.25, 0.50, 1.00] {
-        let vol = surface.black_vol(t, 100.0)?;
+        let vol = surface.black_vol(Tenor(t), Strike(100.0))?;
         assert!(
             vol.0 > 0.05 && vol.0 < 0.50,
             "SSVI ATM vol at T={t} = {:.4}, out of range",
@@ -849,7 +849,7 @@ fn ssvi_surface_build_and_query() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Interpolated tenor
-    let vol_mid = surface.black_vol(0.375, 100.0)?;
+    let vol_mid = surface.black_vol(Tenor(0.375), Strike(100.0))?;
     assert!(
         vol_mid.0 > 0.05 && vol_mid.0 < 0.50,
         "SSVI interpolated ATM vol = {:.4}, out of range",
@@ -867,7 +867,7 @@ fn ssvi_surface_no_nan_full_grid() -> Result<(), Box<dyn std::error::Error>> {
 
     for &t in &tenors {
         for &k in &strikes {
-            let vol = surface.black_vol(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
             assert!(
                 vol.0.is_finite() && vol.0 > 0.0,
                 "SSVI vol({t}, {k}) = {:.6} is invalid",
@@ -889,8 +889,8 @@ fn ssvi_vol_variance_consistency() -> Result<(), Box<dyn std::error::Error>> {
 
     for t in [0.25, 0.375, 0.50, 0.75, 1.00] {
         for k in [80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = surface.black_vol(t, k)?;
-            let var = surface.black_variance(t, k)?;
+            let vol = surface.black_vol(Tenor(t), Strike(k))?;
+            let var = surface.black_variance(Tenor(t), Strike(k))?;
             assert_abs_diff_eq!(vol.0 * vol.0 * t, var.0, epsilon = 1e-10);
         }
     }
@@ -903,15 +903,15 @@ fn ssvi_smile_at_returns_working_section() -> Result<(), Box<dyn std::error::Err
     let surface = build_ssvi_surface();
 
     for t in [0.25, 0.50, 0.75, 1.00] {
-        let smile = surface.smile_at(t)?;
+        let smile = surface.smile_at(Tenor(t))?;
         assert_abs_diff_eq!(smile.expiry(), t, epsilon = 1e-14);
         assert!(smile.forward() > 0.0);
 
-        let vol = smile.vol(100.0)?;
+        let vol = smile.vol(Strike(100.0))?;
         assert!(vol.0 > 0.0 && vol.0 < 1.0);
 
         // Verify smile and surface are consistent at this tenor
-        let surf_vol = surface.black_vol(t, 100.0)?;
+        let surf_vol = surface.black_vol(Tenor(t), Strike(100.0))?;
         assert_abs_diff_eq!(vol.0, surf_vol.0, epsilon = 1e-10);
     }
 
@@ -980,8 +980,8 @@ fn svi_vs_sabr_produce_plausible_vols() -> Result<(), Box<dyn std::error::Error>
     let sabr = SabrSmile::calibrate(forward, expiry, 0.5, &market_data)?;
 
     // Both should produce vols in the same ballpark (< 5% relative difference at ATM)
-    let svi_atm = svi.vol(forward)?.0;
-    let sabr_atm = sabr.vol(forward)?.0;
+    let svi_atm = svi.vol(Strike(forward))?.0;
+    let sabr_atm = sabr.vol(Strike(forward))?.0;
     let rel_diff = (svi_atm - sabr_atm).abs() / svi_atm;
     assert!(
         rel_diff < 0.05,
@@ -990,8 +990,8 @@ fn svi_vs_sabr_produce_plausible_vols() -> Result<(), Box<dyn std::error::Error>
 
     // Check across the strike range — both should be reasonable
     for &k in &strikes {
-        let v_svi = svi.vol(k)?.0;
-        let v_sabr = sabr.vol(k)?.0;
+        let v_svi = svi.vol(Strike(k))?.0;
+        let v_sabr = sabr.vol(Strike(k))?.0;
         assert!(v_svi > 0.0 && v_svi < 1.0);
         assert!(v_sabr > 0.0 && v_sabr < 1.0);
     }
@@ -1006,8 +1006,8 @@ fn piecewise_vs_ssvi_produce_comparable_atm_vols() -> Result<(), Box<dyn std::er
 
     // Both surfaces should produce positive, finite vols at the same tenors
     for t in [0.25, 0.50, 1.00] {
-        let v_pw = piecewise.black_vol(t, 100.0)?.0;
-        let v_ssvi = ssvi.black_vol(t, 100.0)?.0;
+        let v_pw = piecewise.black_vol(Tenor(t), Strike(100.0))?.0;
+        let v_ssvi = ssvi.black_vol(Tenor(t), Strike(100.0))?.0;
         assert!(
             v_pw > 0.0 && v_pw < 1.0,
             "PiecewiseSurface vol({t}, 100) = {v_pw:.4} out of range"
@@ -1035,9 +1035,9 @@ fn concurrent_sabr_surface_queries() -> Result<(), Box<dyn std::error::Error>> {
             thread::spawn(move || -> volsurf::Result<()> {
                 let strike = 80.0 + i as f64 * 5.0;
                 for &t in &[0.25, 0.50, 0.75, 1.00] {
-                    let vol = s.black_vol(t, strike)?;
+                    let vol = s.black_vol(Tenor(t), Strike(strike))?;
                     assert!(vol.0 > 0.0 && vol.0 < 2.0);
-                    let var = s.black_variance(t, strike)?;
+                    let var = s.black_variance(Tenor(t), Strike(strike))?;
                     assert!(var.0 > 0.0 && var.0.is_finite());
                 }
                 Ok(())
@@ -1062,12 +1062,12 @@ fn concurrent_ssvi_surface_queries() -> Result<(), Box<dyn std::error::Error>> {
             thread::spawn(move || -> volsurf::Result<()> {
                 let strike = 80.0 + i as f64 * 5.0;
                 for &t in &[0.25, 0.50, 0.75, 1.00] {
-                    let vol = s.black_vol(t, strike)?;
+                    let vol = s.black_vol(Tenor(t), Strike(strike))?;
                     assert!(vol.0 > 0.0 && vol.0 < 2.0);
                 }
                 // smile_at from thread
-                let smile = s.smile_at(0.5)?;
-                assert!(smile.vol(100.0)?.0 > 0.0);
+                let smile = s.smile_at(Tenor(0.5))?;
+                assert!(smile.vol(Strike(100.0))?.0 > 0.0);
                 Ok(())
             })
         })
@@ -1142,13 +1142,13 @@ fn surface_with_dividend_yield() -> Result<(), Box<dyn std::error::Error>> {
     let surface = builder.build()?;
 
     for &t in &tenors {
-        let smile = surface.smile_at(t)?;
+        let smile = surface.smile_at(Tenor(t))?;
         let expected_fwd = spot * ((rate - q) * t).exp();
         assert_abs_diff_eq!(smile.forward(), expected_fwd, epsilon = 0.5);
     }
 
     // Verify q > 0 gives lower forwards than q = 0
-    let smile_1y = surface.smile_at(1.0)?;
+    let smile_1y = surface.smile_at(Tenor(1.0))?;
     let fwd_no_q = spot * (rate * 1.0_f64).exp();
     assert!(smile_1y.forward() < fwd_no_q);
 
@@ -1209,15 +1209,15 @@ fn mixed_tenor_and_tenor_with_forward() -> Result<(), Box<dyn std::error::Error>
         .build()?;
 
     // 3M should use computed forward
-    let smile_3m = surface.smile_at(0.25)?;
+    let smile_3m = surface.smile_at(Tenor(0.25))?;
     assert_abs_diff_eq!(smile_3m.forward(), fwd_3m, epsilon = 0.5);
 
     // 1Y should use explicit forward, ignoring spot/rate/q
-    let smile_1y = surface.smile_at(1.0)?;
+    let smile_1y = surface.smile_at(Tenor(1.0))?;
     assert_abs_diff_eq!(smile_1y.forward(), explicit_fwd, epsilon = 0.5);
 
     // Cross-tenor query at 6M (interpolation between 3M and 1Y)
-    let vol_6m = surface.black_vol(0.5, 100.0)?;
+    let vol_6m = surface.black_vol(Tenor(0.5), Strike(100.0))?;
     assert!(vol_6m.0 > 0.05 && vol_6m.0 < 0.50);
 
     Ok(())
@@ -1253,7 +1253,7 @@ fn dividend_yield_equals_rate() -> Result<(), Box<dyn std::error::Error>> {
         .add_tenor(1.0, &ks, &vs)
         .build()?;
 
-    let smile = surface.smile_at(1.0)?;
+    let smile = surface.smile_at(Tenor(1.0))?;
     assert_abs_diff_eq!(smile.forward(), spot, epsilon = 0.5);
 
     Ok(())
@@ -1289,7 +1289,7 @@ fn dividend_yield_exceeds_rate() -> Result<(), Box<dyn std::error::Error>> {
         .add_tenor(1.0, &ks, &vs)
         .build()?;
 
-    let smile = surface.smile_at(1.0)?;
+    let smile = surface.smile_at(Tenor(1.0))?;
     assert!(smile.forward() < spot);
     assert_abs_diff_eq!(smile.forward(), fwd, epsilon = 0.5);
 

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -4,9 +4,9 @@
 //! testing fixed examples. They help catch edge cases and ensure robustness.
 
 use proptest::prelude::*;
-use volsurf::conventions;
 use volsurf::smile::{SabrSmile, SmileSection, SplineSmile, SviSmile};
 use volsurf::surface::{PiecewiseSurface, SsviSurface, SurfaceBuilder, VolSurface};
+use volsurf::{Strike, Tenor, conventions};
 
 // --- Property Test 1: SVI vol non-negativity ---
 
@@ -34,7 +34,7 @@ proptest! {
         if let Ok(smile) = smile_result {
             for strike in 80..=120 {
                 let k = strike as f64;
-                let vol = smile.vol(k).unwrap();
+                let vol = smile.vol(Strike(k)).unwrap();
                 prop_assert!(
                     vol.0 >= 0.0,
                     "vol should be non-negative, got {} at strike {}",
@@ -71,8 +71,8 @@ proptest! {
         let smile = smile_result.unwrap();
 
         for strike in [80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol = smile.vol(strike).unwrap();
-            let var = smile.variance(strike).unwrap();
+            let vol = smile.vol(Strike(strike)).unwrap();
+            let var = smile.variance(Strike(strike)).unwrap();
             let expected_var = vol.0 * vol.0 * expiry;
 
             prop_assert!(
@@ -111,7 +111,7 @@ proptest! {
             .unwrap();
 
         for (strike, expected_var) in strikes.iter().zip(variances.iter()) {
-            let var = smile.variance(*strike).unwrap();
+            let var = smile.variance(Strike(*strike)).unwrap();
             prop_assert!(
                 (var.0 - expected_var).abs() < 1e-12,
                 "spline should pass through knot at K={}, got var={} vs expected={}",
@@ -153,8 +153,8 @@ proptest! {
 
         // Query at the exact tenor for various strikes
         for strike in [80.0, 90.0, 100.0, 110.0, 120.0] {
-            let vol_from_surface = surface.black_vol(expiry, strike).unwrap();
-            let vol_from_smile = smile.vol(strike).unwrap();
+            let vol_from_surface = surface.black_vol(Tenor(expiry), Strike(strike)).unwrap();
+            let vol_from_smile = smile.vol(Strike(strike)).unwrap();
 
             prop_assert!(
                 (vol_from_surface.0 - vol_from_smile.0).abs() < 1e-10,
@@ -193,7 +193,7 @@ proptest! {
 
         for strike in 80..=120 {
             let k = strike as f64;
-            if let Ok(v) = sabr.vol(k) {
+            if let Ok(v) = sabr.vol(Strike(k)) {
                 prop_assert!(
                     v.0 >= 0.0,
                     "SABR vol should be non-negative, got {} at strike {}",
@@ -246,7 +246,7 @@ proptest! {
 
         for i in 0..=n_steps {
             let k = k_lo + i as f64 * dk;
-            match sabr.density(k) {
+            match sabr.density(Strike(k)) {
                 Ok(d) => {
                     let weight = if i == 0 || i == n_steps { 0.5 } else { 1.0 };
                     integral += weight * d * dk;
@@ -293,7 +293,7 @@ proptest! {
 
         for strike in (60..=140).step_by(10) {
             let k = strike as f64;
-            let var = surface.black_variance(0.25, k).unwrap();
+            let var = surface.black_variance(Tenor(0.25), Strike(k)).unwrap();
             prop_assert!(
                 var.0 > 0.0,
                 "SSVI variance should be positive, got {} at strike {}",
@@ -334,8 +334,8 @@ proptest! {
 
         for strike in (70..=130).step_by(10) {
             let k = strike as f64;
-            let var_short = surface.black_variance(0.25, k).unwrap();
-            let var_long = surface.black_variance(1.0, k).unwrap();
+            let var_short = surface.black_variance(Tenor(0.25), Strike(k)).unwrap();
+            let var_long = surface.black_variance(Tenor(1.0), Strike(k)).unwrap();
             prop_assert!(
                 var_long.0 >= var_short.0,
                 "variance at T=1.0 ({}) should be >= variance at T=0.25 ({}) at strike {}",
@@ -413,7 +413,7 @@ proptest! {
         let surface = build_result.unwrap();
 
         for (i, &k) in strikes.iter().enumerate() {
-            let queried = surface.black_vol(expiry, k).unwrap();
+            let queried = surface.black_vol(Tenor(expiry), Strike(k)).unwrap();
             prop_assert!(
                 (queried.0 - vols[i]).abs() < 0.02,
                 "round-trip vol at K={} should be within 0.02, got {} vs input {}",

--- a/tests/svi_robustness.rs
+++ b/tests/svi_robustness.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use volsurf::smile::SviSmile;
-use volsurf::{SmileSection, VolSurfError};
+use volsurf::{SmileSection, Strike, VolSurfError};
 
 #[derive(Deserialize)]
 struct Fixture {
@@ -41,7 +41,7 @@ fn assert_calibration_sane(
     }
     match SviSmile::calibrate(forward, expiry, data) {
         Ok(smile) => {
-            let atm = SmileSection::vol(&smile, forward).unwrap().0;
+            let atm = SmileSection::vol(&smile, Strike(forward)).unwrap().0;
             let ratio = atm / expected_atm;
             println!(
                 "{label}: OK  n={:3}  ATM={:.4} expected={:.4} ratio={:.3}",
@@ -267,7 +267,7 @@ fn stable_fixture_must_succeed() {
         }
         let smile = SviSmile::calibrate(f.forward, f.expiry_years, &subset)
             .unwrap_or_else(|e| panic!("stable ±{:.0}% must succeed: {e}", pct * 100.0));
-        let atm = SmileSection::vol(&smile, f.forward).unwrap().0;
+        let atm = SmileSection::vol(&smile, Strike(f.forward)).unwrap().0;
         let ratio = atm / f.expected_atm_iv;
         assert!(
             ratio > 0.8 && ratio < 1.2,

--- a/wasm/src/builder.rs
+++ b/wasm/src/builder.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use volsurf::VolSurface;
 use volsurf::surface::{SmileModel, SurfaceBuilder};
+use volsurf::{Strike, Tenor};
 use wasm_bindgen::prelude::*;
 
 use crate::arbitrage::WasmSurfaceDiagnostics;
@@ -114,19 +115,23 @@ pub struct WasmPiecewiseSurface {
 #[wasm_bindgen]
 impl WasmPiecewiseSurface {
     pub fn black_vol(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
-        Ok(self.inner.black_vol(expiry, strike).map_err(to_js_err)?.0)
+        Ok(self
+            .inner
+            .black_vol(Tenor(expiry), Strike(strike))
+            .map_err(to_js_err)?
+            .0)
     }
 
     pub fn black_variance(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
         Ok(self
             .inner
-            .black_variance(expiry, strike)
+            .black_variance(Tenor(expiry), Strike(strike))
             .map_err(to_js_err)?
             .0)
     }
 
     pub fn smile_at(&self, expiry: f64) -> Result<WasmSmile, JsValue> {
-        let smile = self.inner.smile_at(expiry).map_err(to_js_err)?;
+        let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_js_err)?;
         Ok(WasmSmile::new(smile))
     }
 

--- a/wasm/src/smile.rs
+++ b/wasm/src/smile.rs
@@ -5,6 +5,48 @@ use wasm_bindgen::prelude::*;
 use crate::arbitrage::WasmArbitrageReport;
 use crate::error::to_js_err;
 
+macro_rules! impl_wasm_smile_methods {
+    ($name:ident) => {
+        #[wasm_bindgen]
+        impl $name {
+            pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
+                self.inner
+                    .vol(Strike(strike))
+                    .map(|v| v.0)
+                    .map_err(to_js_err)
+            }
+
+            pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
+                self.inner
+                    .variance(Strike(strike))
+                    .map(|v| v.0)
+                    .map_err(to_js_err)
+            }
+
+            pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
+                self.inner.density(Strike(strike)).map_err(to_js_err)
+            }
+
+            #[wasm_bindgen(getter)]
+            pub fn forward(&self) -> f64 {
+                self.inner.forward()
+            }
+
+            #[wasm_bindgen(getter)]
+            pub fn expiry(&self) -> f64 {
+                self.inner.expiry()
+            }
+
+            pub fn is_arbitrage_free(&self) -> Result<WasmArbitrageReport, JsValue> {
+                self.inner
+                    .is_arbitrage_free()
+                    .map(WasmArbitrageReport::from)
+                    .map_err(to_js_err)
+            }
+        }
+    };
+}
+
 fn pairs_from_flat(flat: &[f64]) -> Result<Vec<(f64, f64)>, JsValue> {
     if !flat.len().is_multiple_of(2) {
         return Err(JsValue::from_str(
@@ -51,41 +93,6 @@ impl WasmSviSmile {
         Ok(Self { inner })
     }
 
-    pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner
-            .vol(Strike(strike))
-            .map(|v| v.0)
-            .map_err(to_js_err)
-    }
-
-    pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner
-            .variance(Strike(strike))
-            .map(|v| v.0)
-            .map_err(to_js_err)
-    }
-
-    pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.density(Strike(strike)).map_err(to_js_err)
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn forward(&self) -> f64 {
-        self.inner.forward()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn expiry(&self) -> f64 {
-        self.inner.expiry()
-    }
-
-    pub fn is_arbitrage_free(&self) -> Result<WasmArbitrageReport, JsValue> {
-        self.inner
-            .is_arbitrage_free()
-            .map(WasmArbitrageReport::from)
-            .map_err(to_js_err)
-    }
-
     pub fn to_json(&self) -> Result<String, JsValue> {
         serde_json::to_string(&self.inner).map_err(|e| JsValue::from_str(&e.to_string()))
     }
@@ -96,6 +103,8 @@ impl WasmSviSmile {
         Ok(Self { inner })
     }
 }
+
+impl_wasm_smile_methods!(WasmSviSmile);
 
 #[wasm_bindgen]
 pub struct WasmSabrSmile {
@@ -128,41 +137,6 @@ impl WasmSabrSmile {
         Ok(Self { inner })
     }
 
-    pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner
-            .vol(Strike(strike))
-            .map(|v| v.0)
-            .map_err(to_js_err)
-    }
-
-    pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner
-            .variance(Strike(strike))
-            .map(|v| v.0)
-            .map_err(to_js_err)
-    }
-
-    pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.density(Strike(strike)).map_err(to_js_err)
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn forward(&self) -> f64 {
-        self.inner.forward()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn expiry(&self) -> f64 {
-        self.inner.expiry()
-    }
-
-    pub fn is_arbitrage_free(&self) -> Result<WasmArbitrageReport, JsValue> {
-        self.inner
-            .is_arbitrage_free()
-            .map(WasmArbitrageReport::from)
-            .map_err(to_js_err)
-    }
-
     pub fn to_json(&self) -> Result<String, JsValue> {
         serde_json::to_string(&self.inner).map_err(|e| JsValue::from_str(&e.to_string()))
     }
@@ -173,6 +147,8 @@ impl WasmSabrSmile {
         Ok(Self { inner })
     }
 }
+
+impl_wasm_smile_methods!(WasmSabrSmile);
 
 #[wasm_bindgen]
 pub struct WasmSmile {
@@ -185,40 +161,4 @@ impl WasmSmile {
     }
 }
 
-#[wasm_bindgen]
-impl WasmSmile {
-    pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner
-            .vol(Strike(strike))
-            .map(|v| v.0)
-            .map_err(to_js_err)
-    }
-
-    pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner
-            .variance(Strike(strike))
-            .map(|v| v.0)
-            .map_err(to_js_err)
-    }
-
-    pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.density(Strike(strike)).map_err(to_js_err)
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn forward(&self) -> f64 {
-        self.inner.forward()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn expiry(&self) -> f64 {
-        self.inner.expiry()
-    }
-
-    pub fn is_arbitrage_free(&self) -> Result<WasmArbitrageReport, JsValue> {
-        self.inner
-            .is_arbitrage_free()
-            .map(WasmArbitrageReport::from)
-            .map_err(to_js_err)
-    }
-}
+impl_wasm_smile_methods!(WasmSmile);

--- a/wasm/src/smile.rs
+++ b/wasm/src/smile.rs
@@ -1,3 +1,4 @@
+use volsurf::Strike;
 use volsurf::smile::{SabrSmile, SmileSection, SviSmile};
 use wasm_bindgen::prelude::*;
 
@@ -51,15 +52,21 @@ impl WasmSviSmile {
     }
 
     pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.vol(strike).map(|v| v.0).map_err(to_js_err)
+        self.inner
+            .vol(Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
     }
 
     pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.variance(strike).map(|v| v.0).map_err(to_js_err)
+        self.inner
+            .variance(Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
     }
 
     pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.density(strike).map_err(to_js_err)
+        self.inner.density(Strike(strike)).map_err(to_js_err)
     }
 
     #[wasm_bindgen(getter)]
@@ -122,15 +129,21 @@ impl WasmSabrSmile {
     }
 
     pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.vol(strike).map(|v| v.0).map_err(to_js_err)
+        self.inner
+            .vol(Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
     }
 
     pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.variance(strike).map(|v| v.0).map_err(to_js_err)
+        self.inner
+            .variance(Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
     }
 
     pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.density(strike).map_err(to_js_err)
+        self.inner.density(Strike(strike)).map_err(to_js_err)
     }
 
     #[wasm_bindgen(getter)]
@@ -175,15 +188,21 @@ impl WasmSmile {
 #[wasm_bindgen]
 impl WasmSmile {
     pub fn vol(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.vol(strike).map(|v| v.0).map_err(to_js_err)
+        self.inner
+            .vol(Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
     }
 
     pub fn variance(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.variance(strike).map(|v| v.0).map_err(to_js_err)
+        self.inner
+            .variance(Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
     }
 
     pub fn density(&self, strike: f64) -> Result<f64, JsValue> {
-        self.inner.density(strike).map_err(to_js_err)
+        self.inner.density(Strike(strike)).map_err(to_js_err)
     }
 
     #[wasm_bindgen(getter)]

--- a/wasm/src/surface.rs
+++ b/wasm/src/surface.rs
@@ -1,5 +1,6 @@
 use volsurf::VolSurface;
 use volsurf::surface::{EssviSurface, PerTenorFit, SsviSurface};
+use volsurf::{Strike, Tenor};
 use wasm_bindgen::prelude::*;
 
 use crate::arbitrage::WasmSurfaceDiagnostics;
@@ -53,13 +54,17 @@ impl WasmSsviSurface {
     }
 
     pub fn black_vol(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
-        Ok(self.inner.black_vol(expiry, strike).map_err(to_js_err)?.0)
+        Ok(self
+            .inner
+            .black_vol(Tenor(expiry), Strike(strike))
+            .map_err(to_js_err)?
+            .0)
     }
 
     pub fn black_variance(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
         Ok(self
             .inner
-            .black_variance(expiry, strike)
+            .black_variance(Tenor(expiry), Strike(strike))
             .map_err(to_js_err)?
             .0)
     }
@@ -92,7 +97,7 @@ impl WasmSsviSurface {
     }
 
     pub fn smile_at(&self, expiry: f64) -> Result<WasmSmile, JsValue> {
-        let smile = self.inner.smile_at(expiry).map_err(to_js_err)?;
+        let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_js_err)?;
         Ok(WasmSmile::new(smile))
     }
 
@@ -151,13 +156,17 @@ impl WasmEssviSurface {
     }
 
     pub fn black_vol(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
-        Ok(self.inner.black_vol(expiry, strike).map_err(to_js_err)?.0)
+        Ok(self
+            .inner
+            .black_vol(Tenor(expiry), Strike(strike))
+            .map_err(to_js_err)?
+            .0)
     }
 
     pub fn black_variance(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
         Ok(self
             .inner
-            .black_variance(expiry, strike)
+            .black_variance(Tenor(expiry), Strike(strike))
             .map_err(to_js_err)?
             .0)
     }
@@ -205,7 +214,7 @@ impl WasmEssviSurface {
     }
 
     pub fn smile_at(&self, expiry: f64) -> Result<WasmSmile, JsValue> {
-        let smile = self.inner.smile_at(expiry).map_err(to_js_err)?;
+        let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_js_err)?;
         Ok(WasmSmile::new(smile))
     }
 


### PR DESCRIPTION
## Summary

- Wrap all trait method inputs (`SmileSection::vol`, `VolSurface::black_vol`, `LocalVol::local_vol`, etc.) with `Strike`/`Tenor` newtypes for compile-time parameter safety
- Update all ~350 internal call sites across core crate, examples, and benchmarks
- Wrap `f64 → Strike`/`Tenor` at Python (PyO3) and WASM (wasm-bindgen) FFI boundaries — **external APIs unchanged** (users still pass bare floats)
- Extract `impl_wasm_smile_methods!` macro to DRY 6 identical SmileSection wrappers across 3 WASM types
- Add 14 NaN/Inf rejection tests for uniform edge-case coverage across all models

## Breaking changes

All Rust trait method signatures change from bare `f64` to newtypes:
```rust
// Before (v1.0)
fn vol(&self, strike: f64) -> Result<Vol>;
fn black_vol(&self, expiry: f64, strike: f64) -> Result<Vol>;

// After (v2.0)
fn vol(&self, strike: Strike) -> Result<Vol>;
fn black_vol(&self, expiry: Tenor, strike: Strike) -> Result<Vol>;
```

Python and WASM bindings are **not affected** — they accept bare floats and wrap internally.

## Validation

- 844 lib + 90 integration + 21 doc tests pass
- 48 WASM tests pass
- 223/225 Python tests pass (2 pre-existing failures, unrelated)
- Zero clippy warnings
- Benchmarks compile and run

## Recommend squash merge

The 6 commits are one logical change — squash preserves clean `main` history while branch retains the layered migration story.

## Test plan

- [x] `cargo test --lib` (844 pass)
- [x] `cargo test --tests` (90 pass)
- [x] `cargo clippy --workspace --all-features` (clean)
- [x] `wasm-pack test --node wasm/` (48 pass)
- [x] `pytest python/tests/` (223/225 pass, 2 pre-existing)
- [x] `cargo bench --bench vol_query -- --test` (compiles)
- [x] `cargo bench --bench surface_construction -- --test` (compiles)