### PR TITLE
docs: add local_vol and essvi_surface examples

### DIFF
--- a/examples/essvi_surface.rs
+++ b/examples/essvi_surface.rs
@@ -216,7 +216,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\neSSVI diverges from SSVI most at short tenors where rho(theta)");
     println!(
-        "is steeper ({:.2} vs {:.2}). They converge at T=2Y where rho -> rho_m.",
+        "is steeper ({:.2} vs {:.2}). They converge at theta_max where rho -> rho_m.",
         surface.rho(*thetas.first().unwrap()),
         surface.rho_m()
     );

--- a/examples/local_vol.rs
+++ b/examples/local_vol.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let arc_surface: Arc<dyn VolSurface> = Arc::new(surface);
     let dupire = DupireLocalVol::new(Arc::clone(&arc_surface));
 
-    println!("Dupire local vol from SSVI surface (default bump_size=1%)\n");
+    println!("Dupire local vol from SSVI surface (default bump_size=0.01)\n");
 
     // ---------------------------------------------------------------
     // 3. Local vol grid


### PR DESCRIPTION
## Summary

- **`examples/local_vol.rs`** — Dupire local volatility (Layer 5). Builds an SSVI surface, wraps in `Arc<dyn VolSurface>`, queries local vol at a (T, K) grid, compares local vol vs implied vol, demonstrates `with_bump_size()` and O(h²) convergence.
- **`examples/essvi_surface.rs`** — Extended SSVI surface (Hendriks-Martini 2019). Direct construction, ρ(θ) across tenors, two-stage calibration (`fit_per_tenor` → `from_per_tenor`), one-shot `calibrate()`, structural calendar-arb check, and eSSVI vs SSVI comparison showing where maturity-dependent ρ matters.

These cover the two major library features that had no example coverage: Dupire local vol (entire Layer 5) and the eSSVI full surface (most advanced Layer 3 model).

## Test plan

- [x] `cargo run --example local_vol` — clean output
- [x] `cargo run --example essvi_surface` — clean output
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --lib` — 844 tests pass
- [x] Code reviewed: fixed theta/tenor convergence wording, bump_size ambiguity