### PR TITLE
chore: sync binding package versions to 2.0.0

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-python"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2024"
 publish = false
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "volsurf"
-version = "0.1.0"
+version = "2.0.0"
 requires-python = ">=3.9"
 dependencies = ["numpy>=1.24"]
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-wasm"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "WebAssembly bindings for volsurf"


### PR DESCRIPTION
## Summary
- Bumps `python/pyproject.toml`, `python/Cargo.toml`, and `wasm/Cargo.toml` from `0.1.0` to `2.0.0`
- All three are `publish = false` — purely cosmetic, but keeps `pip show volsurf` and Cargo metadata consistent with the core crate

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `maturin develop --release -m python/Cargo.toml` reports `volsurf-2.0.0`
- [ ] `pip show volsurf` shows `Version: 2.0.0`