### PR TITLE
feat: configurable arbitrage scan grids (#84)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -18,6 +18,7 @@ fn volsurf(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySurface>()?;
     m.add_class::<PySmileModel>()?;
     m.add_class::<PyDataFilter>()?;
+    m.add_class::<PyArbitrageScanConfig>()?;
     m.add_class::<PyWeightingScheme>()?;
     m.add_class::<PyOptionType>()?;
     m.add_class::<PyArbitrageReport>()?;

--- a/python/src/smile.rs
+++ b/python/src/smile.rs
@@ -5,7 +5,7 @@ use volsurf::Strike;
 use volsurf::smile::{SabrSmile, SmileSection, SplineSmile, SviSmile};
 
 use crate::error::to_py_err;
-use crate::types::PyArbitrageReport;
+use crate::types::{PyArbitrageReport, PyArbitrageScanConfig};
 
 macro_rules! impl_smile_methods {
     ($name:ident) => {
@@ -35,6 +35,17 @@ macro_rules! impl_smile_methods {
 
             fn is_arbitrage_free(&self) -> PyResult<PyArbitrageReport> {
                 Ok(self.inner.is_arbitrage_free().map_err(to_py_err)?.into())
+            }
+
+            fn is_arbitrage_free_with(
+                &self,
+                config: &PyArbitrageScanConfig,
+            ) -> PyResult<PyArbitrageReport> {
+                Ok(self
+                    .inner
+                    .is_arbitrage_free_with(&config.inner)
+                    .map_err(to_py_err)?
+                    .into())
             }
 
             fn to_json(&self) -> PyResult<String> {

--- a/python/src/surface.rs
+++ b/python/src/surface.rs
@@ -8,7 +8,7 @@ use volsurf::surface::{EssviSurface, PerTenorFit, SsviSurface, SurfaceBuilder};
 use volsurf::{Strike, Tenor};
 
 use crate::error::to_py_err;
-use crate::types::{PySmile, PySmileModel, PySurface, PySurfaceDiagnostics};
+use crate::types::{PyArbitrageScanConfig, PySmile, PySmileModel, PySurface, PySurfaceDiagnostics};
 
 macro_rules! impl_vol_grid {
     ($name:ident) => {
@@ -89,6 +89,14 @@ impl PySsviSurface {
 
     fn diagnostics(&self) -> PyResult<PySurfaceDiagnostics> {
         Ok(self.inner.diagnostics().map_err(to_py_err)?.into())
+    }
+
+    fn diagnostics_with(&self, config: &PyArbitrageScanConfig) -> PyResult<PySurfaceDiagnostics> {
+        Ok(self
+            .inner
+            .diagnostics_with(&config.inner)
+            .map_err(to_py_err)?
+            .into())
     }
 
     #[getter]
@@ -246,6 +254,14 @@ impl PyEssviSurface {
 
     fn diagnostics(&self) -> PyResult<PySurfaceDiagnostics> {
         Ok(self.inner.diagnostics().map_err(to_py_err)?.into())
+    }
+
+    fn diagnostics_with(&self, config: &PyArbitrageScanConfig) -> PyResult<PySurfaceDiagnostics> {
+        Ok(self
+            .inner
+            .diagnostics_with(&config.inner)
+            .map_err(to_py_err)?
+            .into())
     }
 
     #[getter]

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -5,7 +5,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 use volsurf::calibration::{DataFilter, WeightingScheme};
-use volsurf::smile::{ArbitrageReport, ButterflyViolation};
+use volsurf::smile::{ArbitrageReport, ArbitrageScanConfig, ButterflyViolation};
 use volsurf::surface::{CalendarViolation, SmileModel, SurfaceDiagnostics};
 use volsurf::{OptionType, SmileSection, Strike, Tenor, VolSurface};
 
@@ -127,6 +127,64 @@ impl PyDataFilter {
     }
 }
 
+#[pyclass(frozen, from_py_object, name = "ArbitrageScanConfig")]
+#[derive(Clone)]
+pub struct PyArbitrageScanConfig {
+    pub(crate) inner: ArbitrageScanConfig,
+}
+
+#[pymethods]
+impl PyArbitrageScanConfig {
+    #[new]
+    #[pyo3(signature = (n_points, k_min, k_max))]
+    fn new(n_points: usize, k_min: f64, k_max: f64) -> Self {
+        Self {
+            inner: ArbitrageScanConfig {
+                n_points,
+                k_min,
+                k_max,
+            },
+        }
+    }
+
+    #[staticmethod]
+    fn svi_default() -> Self {
+        Self {
+            inner: ArbitrageScanConfig::svi_default(),
+        }
+    }
+
+    #[staticmethod]
+    fn sabr_default() -> Self {
+        Self {
+            inner: ArbitrageScanConfig::sabr_default(),
+        }
+    }
+
+    #[getter]
+    fn n_points(&self) -> usize {
+        self.inner.n_points
+    }
+
+    #[getter]
+    fn k_min(&self) -> f64 {
+        self.inner.k_min
+    }
+
+    #[getter]
+    fn k_max(&self) -> f64 {
+        self.inner.k_max
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self.inner)
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
 #[pyclass(frozen, from_py_object, name = "WeightingScheme")]
 #[derive(Clone)]
 pub struct PyWeightingScheme {
@@ -198,6 +256,17 @@ impl PySmile {
         Ok(self.inner.is_arbitrage_free().map_err(to_py_err)?.into())
     }
 
+    fn is_arbitrage_free_with(
+        &self,
+        config: &PyArbitrageScanConfig,
+    ) -> PyResult<PyArbitrageReport> {
+        Ok(self
+            .inner
+            .is_arbitrage_free_with(&config.inner)
+            .map_err(to_py_err)?
+            .into())
+    }
+
     #[pyo3(signature = (strikes))]
     fn vol_array<'py>(
         &self,
@@ -247,6 +316,14 @@ impl PySurface {
 
     fn diagnostics(&self) -> PyResult<PySurfaceDiagnostics> {
         Ok(self.inner.diagnostics().map_err(to_py_err)?.into())
+    }
+
+    fn diagnostics_with(&self, config: &PyArbitrageScanConfig) -> PyResult<PySurfaceDiagnostics> {
+        Ok(self
+            .inner
+            .diagnostics_with(&config.inner)
+            .map_err(to_py_err)?
+            .into())
     }
 
     #[pyo3(signature = (expiries, strikes))]

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -173,6 +173,12 @@ mod tests {
         fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
             unimplemented!()
         }
+        fn diagnostics_with(
+            &self,
+            _: &crate::smile::ArbitrageScanConfig,
+        ) -> error::Result<SurfaceDiagnostics> {
+            unimplemented!()
+        }
     }
 
     fn stub_surface() -> Arc<dyn VolSurface> {
@@ -226,6 +232,12 @@ mod tests {
             }))
         }
         fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
+            unimplemented!()
+        }
+        fn diagnostics_with(
+            &self,
+            _: &crate::smile::ArbitrageScanConfig,
+        ) -> error::Result<SurfaceDiagnostics> {
             unimplemented!()
         }
     }
@@ -459,6 +471,12 @@ mod tests {
                 Ok(Box::new(ZeroFwdSmile))
             }
             fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
+                unimplemented!()
+            }
+            fn diagnostics_with(
+                &self,
+                _: &crate::smile::ArbitrageScanConfig,
+            ) -> error::Result<SurfaceDiagnostics> {
                 unimplemented!()
             }
         }

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -209,9 +209,6 @@ mod tests {
         fn density(&self, _: Strike) -> error::Result<f64> {
             unimplemented!()
         }
-        fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
-            unimplemented!()
-        }
     }
 
     impl VolSurface for FlatVolSurface {
@@ -447,9 +444,6 @@ mod tests {
                 0.5
             }
             fn density(&self, _: Strike) -> error::Result<f64> {
-                unimplemented!()
-            }
-            fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
                 unimplemented!()
             }
         }

--- a/src/smile/arbitrage.rs
+++ b/src/smile/arbitrage.rs
@@ -293,4 +293,117 @@ mod tests {
         assert!(report.is_free, "conservative SSVI should be arb-free");
         assert!(report.worst_violation().is_none());
     }
+
+    // ========== ArbitrageScanConfig ==========
+
+    #[test]
+    fn svi_default_config_matches_hardcoded() {
+        use crate::smile::{ArbitrageScanConfig, SviSmile};
+        let svi = SviSmile::new(100.0, 1.0, 0.04, 0.1, -0.5, 0.0, 0.3).unwrap();
+        let default_report = svi.is_arbitrage_free().unwrap();
+        let config_report = svi
+            .is_arbitrage_free_with(&ArbitrageScanConfig::svi_default())
+            .unwrap();
+        assert_eq!(default_report.is_free, config_report.is_free);
+        assert_eq!(
+            default_report.butterfly_violations.len(),
+            config_report.butterfly_violations.len()
+        );
+    }
+
+    #[test]
+    fn sabr_default_config_matches_hardcoded() {
+        use crate::smile::{ArbitrageScanConfig, SabrSmile};
+        let sabr = SabrSmile::new(100.0, 1.0, 0.3, 0.5, -0.5, 2.0).unwrap();
+        let default_report = sabr.is_arbitrage_free().unwrap();
+        let config_report = sabr
+            .is_arbitrage_free_with(&ArbitrageScanConfig::sabr_default())
+            .unwrap();
+        assert_eq!(default_report.is_free, config_report.is_free);
+        assert_eq!(
+            default_report.butterfly_violations.len(),
+            config_report.butterfly_violations.len()
+        );
+    }
+
+    #[test]
+    fn higher_n_points_finds_more_violations() {
+        use crate::smile::{ArbitrageScanConfig, SviSmile};
+        // Params that produce wing violations
+        let svi = SviSmile::new(100.0, 1.0, 0.04, 0.4, -0.9, 0.1, 0.2).unwrap();
+        let coarse = svi
+            .is_arbitrage_free_with(&ArbitrageScanConfig {
+                n_points: 20,
+                k_min: -3.0,
+                k_max: 3.0,
+            })
+            .unwrap();
+        let fine = svi
+            .is_arbitrage_free_with(&ArbitrageScanConfig {
+                n_points: 500,
+                k_min: -3.0,
+                k_max: 3.0,
+            })
+            .unwrap();
+        assert!(
+            fine.butterfly_violations.len() >= coarse.butterfly_violations.len(),
+            "finer grid should find at least as many violations"
+        );
+    }
+
+    #[test]
+    fn narrow_range_misses_wing_violations() {
+        use crate::smile::{ArbitrageScanConfig, SabrSmile};
+        let sabr = SabrSmile::new(100.0, 1.0, 0.3, 0.5, -0.5, 2.0).unwrap();
+        let wide = sabr
+            .is_arbitrage_free_with(&ArbitrageScanConfig::sabr_default())
+            .unwrap();
+        let narrow = sabr
+            .is_arbitrage_free_with(&ArbitrageScanConfig {
+                n_points: 200,
+                k_min: -0.5,
+                k_max: 0.5,
+            })
+            .unwrap();
+        assert!(
+            narrow.butterfly_violations.len() <= wide.butterfly_violations.len(),
+            "narrow range should find fewer violations"
+        );
+    }
+
+    #[test]
+    fn config_rejects_n_points_below_two() {
+        use crate::smile::{ArbitrageScanConfig, SviSmile};
+        let svi = SviSmile::new(100.0, 1.0, 0.04, 0.1, -0.5, 0.0, 0.3).unwrap();
+        let config = ArbitrageScanConfig {
+            n_points: 1,
+            k_min: -3.0,
+            k_max: 3.0,
+        };
+        assert!(svi.is_arbitrage_free_with(&config).is_err());
+    }
+
+    #[test]
+    fn config_rejects_inverted_range() {
+        use crate::smile::{ArbitrageScanConfig, SviSmile};
+        let svi = SviSmile::new(100.0, 1.0, 0.04, 0.1, -0.5, 0.0, 0.3).unwrap();
+        let config = ArbitrageScanConfig {
+            n_points: 200,
+            k_min: 3.0,
+            k_max: -3.0,
+        };
+        assert!(svi.is_arbitrage_free_with(&config).is_err());
+    }
+
+    #[test]
+    fn config_rejects_nan() {
+        use crate::smile::{ArbitrageScanConfig, SviSmile};
+        let svi = SviSmile::new(100.0, 1.0, 0.04, 0.1, -0.5, 0.0, 0.3).unwrap();
+        let config = ArbitrageScanConfig {
+            n_points: 200,
+            k_min: f64::NAN,
+            k_max: 3.0,
+        };
+        assert!(svi.is_arbitrage_free_with(&config).is_err());
+    }
 }

--- a/src/smile/mod.rs
+++ b/src/smile/mod.rs
@@ -27,6 +27,58 @@ use crate::implied::black::black_price;
 use crate::types::{OptionType, Strike, Variance, Vol};
 use crate::validate::validate_positive;
 
+/// Grid configuration for butterfly arbitrage scanning.
+///
+/// Controls the number of sample points and log-moneyness range
+/// k = ln(K/F) used when checking `is_arbitrage_free_with`.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ArbitrageScanConfig {
+    pub n_points: usize,
+    pub k_min: f64,
+    pub k_max: f64,
+}
+
+impl ArbitrageScanConfig {
+    /// Default for SVI and SSVI models: 200 points over [-3, 3].
+    pub fn svi_default() -> Self {
+        Self {
+            n_points: 200,
+            k_min: -3.0,
+            k_max: 3.0,
+        }
+    }
+
+    /// Default for SABR model: 200 points over [-2, 2].
+    ///
+    /// Narrower range than SVI because Hagan formula breaks down in deep wings.
+    pub fn sabr_default() -> Self {
+        Self {
+            n_points: 200,
+            k_min: -2.0,
+            k_max: 2.0,
+        }
+    }
+
+    pub(crate) fn validate(&self) -> error::Result<()> {
+        if self.n_points < 2 {
+            return Err(error::VolSurfError::InvalidInput {
+                message: format!("n_points must be >= 2, got {}", self.n_points),
+            });
+        }
+        if !self.k_min.is_finite() || !self.k_max.is_finite() {
+            return Err(error::VolSurfError::InvalidInput {
+                message: "k_min and k_max must be finite".to_string(),
+            });
+        }
+        if self.k_min >= self.k_max {
+            return Err(error::VolSurfError::InvalidInput {
+                message: format!("k_min ({}) must be < k_max ({})", self.k_min, self.k_max),
+            });
+        }
+        Ok(())
+    }
+}
+
 /// A single-tenor volatility smile.
 ///
 /// Represents the relationship between strike and implied volatility at a
@@ -133,5 +185,46 @@ pub trait SmileSection: Send + Sync + std::fmt::Debug {
     fn expiry(&self) -> f64;
 
     /// Check whether this smile is free of butterfly arbitrage.
-    fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport>;
+    ///
+    /// Uses model-specific defaults for scan grid. Override this or
+    /// [`is_arbitrage_free_with`](SmileSection::is_arbitrage_free_with)
+    /// for custom grid parameters.
+    fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
+        self.is_arbitrage_free_with(&ArbitrageScanConfig::svi_default())
+    }
+
+    /// Check butterfly arbitrage with custom scan grid configuration.
+    ///
+    /// Default implementation uses density-based detection (Breeden-Litzenberger)
+    /// over `config.n_points` equally-spaced log-moneyness points in
+    /// `[config.k_min, config.k_max]`. Models with analytical g-functions
+    /// (SVI, SSVI) override this for better accuracy.
+    fn is_arbitrage_free_with(
+        &self,
+        config: &ArbitrageScanConfig,
+    ) -> error::Result<ArbitrageReport> {
+        config.validate()?;
+        let fwd = self.forward();
+        let n = config.n_points;
+        let mut violations = Vec::new();
+        for i in 0..n {
+            let k = config.k_min + (config.k_max - config.k_min) * (i as f64) / ((n - 1) as f64);
+            let strike = fwd * k.exp();
+            let d = match self.density(Strike(strike)) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            if d < -DENSITY_NEG_TOL {
+                violations.push(ButterflyViolation {
+                    strike,
+                    density: d,
+                    magnitude: d.abs(),
+                });
+            }
+        }
+        Ok(ArbitrageReport {
+            is_free: violations.is_empty(),
+            butterfly_violations: violations,
+        })
+    }
 }

--- a/src/smile/sabr.rs
+++ b/src/smile/sabr.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::calibration::{DataFilter, WeightingScheme, apply_filter};
 use crate::error::{self, VolSurfError};
+use crate::smile::ArbitrageScanConfig;
 use crate::smile::SmileSection;
 use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
 use crate::types::{Strike, Vol};
@@ -589,17 +590,22 @@ impl SmileSection for SabrSmile {
     /// # Reference
     /// Hagan et al. (2002), "Managing Smile Risk".
     fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
-        const N: usize = 200;
-        const K_MIN: f64 = -2.0;
-        const K_MAX: f64 = 2.0;
+        self.is_arbitrage_free_with(&ArbitrageScanConfig::sabr_default())
+    }
 
+    fn is_arbitrage_free_with(
+        &self,
+        config: &ArbitrageScanConfig,
+    ) -> error::Result<ArbitrageReport> {
+        config.validate()?;
+        let n = config.n_points;
         let mut violations = Vec::new();
-        for i in 0..N {
-            let k = K_MIN + (K_MAX - K_MIN) * (i as f64) / ((N - 1) as f64);
+        for i in 0..n {
+            let k = config.k_min + (config.k_max - config.k_min) * (i as f64) / ((n - 1) as f64);
             let strike = self.forward * k.exp();
             let d = match self.density(Strike(strike)) {
                 Ok(d) => d,
-                Err(_) => continue, // Hagan breakdown in wings
+                Err(_) => continue,
             };
             if d < -super::DENSITY_NEG_TOL {
                 violations.push(ButterflyViolation {

--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -21,6 +21,7 @@ use nalgebra::{DMatrix, DVector};
 
 use crate::calibration::{DataFilter, WeightingScheme, apply_filter};
 use crate::error::{self, VolSurfError};
+use crate::smile::ArbitrageScanConfig;
 use crate::smile::SmileSection;
 use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
 use crate::types::{Strike, Vol};
@@ -670,16 +671,19 @@ impl SmileSection for SviSmile {
     /// # Reference
     /// Gatheral & Jacquier (2014), Theorem 4.1.
     fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
-        /// Number of grid points for g-function arbitrage scan.
-        const N: usize = 200;
-        /// Minimum log-moneyness for arbitrage scan.
-        const K_MIN: f64 = -3.0;
-        /// Maximum log-moneyness for arbitrage scan.
-        const K_MAX: f64 = 3.0;
+        self.is_arbitrage_free_with(&ArbitrageScanConfig::svi_default())
+    }
+
+    fn is_arbitrage_free_with(
+        &self,
+        config: &ArbitrageScanConfig,
+    ) -> error::Result<ArbitrageReport> {
+        config.validate()?;
+        let n = config.n_points;
         let mut violations = Vec::new();
 
-        for i in 0..N {
-            let k = K_MIN + (K_MAX - K_MIN) * (i as f64) / ((N - 1) as f64);
+        for i in 0..n {
+            let k = config.k_min + (config.k_max - config.k_min) * (i as f64) / ((n - 1) as f64);
             let g = self.g_function(k);
             if g < -super::BUTTERFLY_G_TOL {
                 let strike = self.forward * k.exp();

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::calibration::{DataFilter, WeightingScheme, apply_filter};
 use crate::error::{self, VolSurfError};
-use crate::smile::SmileSection;
 use crate::smile::arbitrage::ArbitrageReport;
+use crate::smile::{ArbitrageScanConfig, SmileSection};
 use crate::surface::CALENDAR_ARB_TOL;
 use crate::surface::VolSurface;
 use crate::surface::arbitrage::{CalendarViolation, SurfaceDiagnostics};
@@ -215,6 +215,13 @@ impl SmileSection for EssviSlice {
 
     fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
         self.0.is_arbitrage_free()
+    }
+
+    fn is_arbitrage_free_with(
+        &self,
+        config: &ArbitrageScanConfig,
+    ) -> error::Result<ArbitrageReport> {
+        self.0.is_arbitrage_free_with(config)
     }
 }
 

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -1068,6 +1068,10 @@ impl VolSurface for EssviSurface {
     }
 
     fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
+        self.diagnostics_with(&ArbitrageScanConfig::svi_default())
+    }
+
+    fn diagnostics_with(&self, config: &ArbitrageScanConfig) -> error::Result<SurfaceDiagnostics> {
         let mut smile_reports = Vec::with_capacity(self.tenors.len());
         for (i, &tenor) in self.tenors.iter().enumerate() {
             let rho = self.rho(self.thetas[i]);
@@ -1079,7 +1083,7 @@ impl VolSurface for EssviSurface {
                 self.gamma,
                 self.thetas[i],
             )?;
-            smile_reports.push(slice.is_arbitrage_free()?);
+            smile_reports.push(slice.is_arbitrage_free_with(config)?);
         }
 
         let mut calendar_violations = Vec::new();

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -26,7 +26,7 @@ pub(crate) const CALENDAR_ARB_TOL: f64 = 1e-10;
 pub(crate) const EXPIRY_MATCH_TOL: f64 = 1e-10;
 
 use crate::error;
-use crate::smile::SmileSection;
+use crate::smile::{ArbitrageScanConfig, SmileSection};
 use crate::types::{Strike, Tenor, Variance, Vol};
 
 /// A full volatility surface: (expiry, strike) → vol.
@@ -91,4 +91,10 @@ pub trait VolSurface: Send + Sync + std::fmt::Debug {
 
     /// Surface-level arbitrage diagnostics (butterfly + calendar).
     fn diagnostics(&self) -> error::Result<SurfaceDiagnostics>;
+
+    /// Surface-level diagnostics with custom butterfly scan configuration.
+    ///
+    /// Passes `config` through to per-smile `is_arbitrage_free_with()` calls.
+    /// Calendar spread checks use the same hardcoded grid as `diagnostics()`.
+    fn diagnostics_with(&self, config: &ArbitrageScanConfig) -> error::Result<SurfaceDiagnostics>;
 }

--- a/src/surface/piecewise.rs
+++ b/src/surface/piecewise.rs
@@ -25,8 +25,9 @@
 use std::fmt;
 
 use crate::error::{self, VolSurfError};
-use crate::smile::SmileSection;
+use crate::smile::arbitrage::ArbitrageReport;
 use crate::smile::spline::SplineSmile;
+use crate::smile::{ArbitrageScanConfig, SmileSection};
 use crate::surface::VolSurface;
 use crate::surface::arbitrage::{CalendarViolation, SurfaceDiagnostics};
 use crate::surface::{CALENDAR_ARB_TOL, EXPIRY_MATCH_TOL};
@@ -181,6 +182,43 @@ enum TenorPosition {
     Between(usize, usize),
 }
 
+impl PiecewiseSurface {
+    fn diagnostics_from_smile_reports(
+        &self,
+        smile_reports: Vec<ArbitrageReport>,
+    ) -> error::Result<SurfaceDiagnostics> {
+        let mut calendar_violations = Vec::new();
+        for i in 0..self.tenors.len().saturating_sub(1) {
+            let f1 = self.smiles[i].forward();
+            let f2 = self.smiles[i + 1].forward();
+            let fwd_avg = 0.5 * (f1 + f2);
+            let grid = Self::strike_grid(fwd_avg, CALENDAR_CHECK_GRID_SIZE);
+
+            for &k in &grid {
+                let w_short = self.smiles[i].variance(Strike(k))?;
+                let w_long = self.smiles[i + 1].variance(Strike(k))?;
+                if w_long.0 < w_short.0 - CALENDAR_ARB_TOL {
+                    calendar_violations.push(CalendarViolation {
+                        strike: k,
+                        tenor_short: self.tenors[i],
+                        tenor_long: self.tenors[i + 1],
+                        variance_short: w_short.0,
+                        variance_long: w_long.0,
+                    });
+                }
+            }
+        }
+
+        let is_free = smile_reports.iter().all(|r| r.is_free) && calendar_violations.is_empty();
+
+        Ok(SurfaceDiagnostics {
+            smile_reports,
+            calendar_violations,
+            is_free,
+        })
+    }
+}
+
 impl VolSurface for PiecewiseSurface {
     fn black_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol> {
         validate_positive(expiry.0, "expiry")?;
@@ -284,42 +322,19 @@ impl VolSurface for PiecewiseSurface {
     }
 
     fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
-        // Collect per-tenor butterfly reports
         let mut smile_reports = Vec::with_capacity(self.smiles.len());
         for smile in &self.smiles {
             smile_reports.push(smile.is_arbitrage_free()?);
         }
+        self.diagnostics_from_smile_reports(smile_reports)
+    }
 
-        // Calendar spread checks between consecutive tenors
-        let mut calendar_violations = Vec::new();
-        for i in 0..self.tenors.len().saturating_sub(1) {
-            let f1 = self.smiles[i].forward();
-            let f2 = self.smiles[i + 1].forward();
-            let fwd_avg = 0.5 * (f1 + f2);
-            let grid = Self::strike_grid(fwd_avg, CALENDAR_CHECK_GRID_SIZE);
-
-            for &k in &grid {
-                let w_short = self.smiles[i].variance(Strike(k))?;
-                let w_long = self.smiles[i + 1].variance(Strike(k))?;
-                if w_long.0 < w_short.0 - CALENDAR_ARB_TOL {
-                    calendar_violations.push(CalendarViolation {
-                        strike: k,
-                        tenor_short: self.tenors[i],
-                        tenor_long: self.tenors[i + 1],
-                        variance_short: w_short.0,
-                        variance_long: w_long.0,
-                    });
-                }
-            }
+    fn diagnostics_with(&self, config: &ArbitrageScanConfig) -> error::Result<SurfaceDiagnostics> {
+        let mut smile_reports = Vec::with_capacity(self.smiles.len());
+        for smile in &self.smiles {
+            smile_reports.push(smile.is_arbitrage_free_with(config)?);
         }
-
-        let is_free = smile_reports.iter().all(|r| r.is_free) && calendar_violations.is_empty();
-
-        Ok(SurfaceDiagnostics {
-            smile_reports,
-            calendar_violations,
-            is_free,
-        })
+        self.diagnostics_from_smile_reports(smile_reports)
     }
 }
 

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -32,8 +32,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::calibration::{DataFilter, WeightingScheme};
 use crate::error::{self, VolSurfError};
-use crate::smile::SmileSection;
 use crate::smile::arbitrage::{ArbitrageReport, ButterflyViolation};
+use crate::smile::{ArbitrageScanConfig, SmileSection};
 use crate::surface::CALENDAR_ARB_TOL;
 use crate::surface::VolSurface;
 use crate::surface::arbitrage::{CalendarViolation, SurfaceDiagnostics};
@@ -978,16 +978,19 @@ impl SmileSection for SsviSlice {
     /// # Reference
     /// Gatheral & Jacquier (2014), Theorem 4.1.
     fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
-        /// Number of grid points for g-function arbitrage scan.
-        const N: usize = 200;
-        /// Minimum log-moneyness for arbitrage scan.
-        const K_MIN: f64 = -3.0;
-        /// Maximum log-moneyness for arbitrage scan.
-        const K_MAX: f64 = 3.0;
+        self.is_arbitrage_free_with(&ArbitrageScanConfig::svi_default())
+    }
+
+    fn is_arbitrage_free_with(
+        &self,
+        config: &ArbitrageScanConfig,
+    ) -> error::Result<ArbitrageReport> {
+        config.validate()?;
+        let n = config.n_points;
         let mut violations = Vec::new();
 
-        for i in 0..N {
-            let k = K_MIN + (K_MAX - K_MIN) * (i as f64) / ((N - 1) as f64);
+        for i in 0..n {
+            let k = config.k_min + (config.k_max - config.k_min) * (i as f64) / ((n - 1) as f64);
             let g = self.g_function(k);
             if g < -crate::smile::BUTTERFLY_G_TOL {
                 let strike = self.forward * k.exp();

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -657,7 +657,10 @@ impl VolSurface for SsviSurface {
     }
 
     fn diagnostics(&self) -> error::Result<SurfaceDiagnostics> {
-        // Per-tenor butterfly reports
+        self.diagnostics_with(&ArbitrageScanConfig::svi_default())
+    }
+
+    fn diagnostics_with(&self, config: &ArbitrageScanConfig) -> error::Result<SurfaceDiagnostics> {
         let mut smile_reports = Vec::with_capacity(self.tenors.len());
         for (i, &tenor) in self.tenors.iter().enumerate() {
             let slice = SsviSlice::new(
@@ -668,10 +671,9 @@ impl VolSurface for SsviSurface {
                 self.gamma,
                 self.thetas[i],
             )?;
-            smile_reports.push(slice.is_arbitrage_free()?);
+            smile_reports.push(slice.is_arbitrage_free_with(config)?);
         }
 
-        // Calendar spread checks between consecutive tenors
         let mut calendar_violations = Vec::new();
         for i in 0..self.tenors.len().saturating_sub(1) {
             let f_avg = 0.5 * (self.forwards[i] + self.forwards[i + 1]);

--- a/wasm/src/builder.rs
+++ b/wasm/src/builder.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::arbitrage::WasmSurfaceDiagnostics;
 use crate::error::to_js_err;
-use crate::smile::WasmSmile;
+use crate::smile::{WasmArbitrageScanConfig, WasmSmile};
 
 fn consumed() -> JsValue {
     JsValue::from_str("builder already consumed by build()")
@@ -171,6 +171,16 @@ impl WasmPiecewiseSurface {
     pub fn diagnostics(&self) -> Result<WasmSurfaceDiagnostics, JsValue> {
         self.inner
             .diagnostics()
+            .map(WasmSurfaceDiagnostics::from)
+            .map_err(to_js_err)
+    }
+
+    pub fn diagnostics_with(
+        &self,
+        config: &WasmArbitrageScanConfig,
+    ) -> Result<WasmSurfaceDiagnostics, JsValue> {
+        self.inner
+            .diagnostics_with(&config.inner())
             .map(WasmSurfaceDiagnostics::from)
             .map_err(to_js_err)
     }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -11,8 +11,8 @@ pub use arbitrage::{
 };
 pub use builder::{WasmPiecewiseSurface, WasmSurfaceBuilder};
 pub use smile::{
-    WasmDataFilter, WasmSabrSmile, WasmSmile, WasmSviSmile, WasmWeightingScheme,
-    weighting_model_default, weighting_uniform, weighting_vega,
+    WasmArbitrageScanConfig, WasmDataFilter, WasmSabrSmile, WasmSmile, WasmSviSmile,
+    WasmWeightingScheme, weighting_model_default, weighting_uniform, weighting_vega,
 };
 pub use surface::{WasmEssviSurface, WasmPerTenorFit, WasmSsviSurface};
 

--- a/wasm/src/smile.rs
+++ b/wasm/src/smile.rs
@@ -50,7 +50,7 @@ macro_rules! impl_wasm_smile_methods {
                 config: &WasmArbitrageScanConfig,
             ) -> Result<WasmArbitrageReport, JsValue> {
                 self.inner
-                    .is_arbitrage_free_with(&config.inner)
+                    .is_arbitrage_free_with(&config.inner())
                     .map(WasmArbitrageReport::from)
                     .map_err(to_js_err)
             }

--- a/wasm/src/smile.rs
+++ b/wasm/src/smile.rs
@@ -1,6 +1,6 @@
 use volsurf::Strike;
 use volsurf::calibration::{DataFilter, WeightingScheme};
-use volsurf::smile::{SabrSmile, SmileSection, SviSmile};
+use volsurf::smile::{ArbitrageScanConfig, SabrSmile, SmileSection, SviSmile};
 use wasm_bindgen::prelude::*;
 
 use crate::arbitrage::WasmArbitrageReport;
@@ -41,6 +41,16 @@ macro_rules! impl_wasm_smile_methods {
             pub fn is_arbitrage_free(&self) -> Result<WasmArbitrageReport, JsValue> {
                 self.inner
                     .is_arbitrage_free()
+                    .map(WasmArbitrageReport::from)
+                    .map_err(to_js_err)
+            }
+
+            pub fn is_arbitrage_free_with(
+                &self,
+                config: &WasmArbitrageScanConfig,
+            ) -> Result<WasmArbitrageReport, JsValue> {
+                self.inner
+                    .is_arbitrage_free_with(&config.inner)
                     .map(WasmArbitrageReport::from)
                     .map_err(to_js_err)
             }
@@ -98,6 +108,58 @@ impl WasmDataFilter {
     #[wasm_bindgen(getter)]
     pub fn vol_cliff_filter(&self) -> Option<bool> {
         self.inner.vol_cliff_filter
+    }
+}
+
+#[wasm_bindgen]
+pub struct WasmArbitrageScanConfig {
+    inner: ArbitrageScanConfig,
+}
+
+impl WasmArbitrageScanConfig {
+    pub(crate) fn inner(&self) -> ArbitrageScanConfig {
+        self.inner
+    }
+}
+
+#[wasm_bindgen]
+impl WasmArbitrageScanConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new(n_points: usize, k_min: f64, k_max: f64) -> WasmArbitrageScanConfig {
+        Self {
+            inner: ArbitrageScanConfig {
+                n_points,
+                k_min,
+                k_max,
+            },
+        }
+    }
+
+    pub fn svi_default() -> WasmArbitrageScanConfig {
+        Self {
+            inner: ArbitrageScanConfig::svi_default(),
+        }
+    }
+
+    pub fn sabr_default() -> WasmArbitrageScanConfig {
+        Self {
+            inner: ArbitrageScanConfig::sabr_default(),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn n_points(&self) -> usize {
+        self.inner.n_points
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn k_min(&self) -> f64 {
+        self.inner.k_min
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn k_max(&self) -> f64 {
+        self.inner.k_max
     }
 }
 

--- a/wasm/src/surface.rs
+++ b/wasm/src/surface.rs
@@ -5,7 +5,9 @@ use wasm_bindgen::prelude::*;
 
 use crate::arbitrage::WasmSurfaceDiagnostics;
 use crate::error::to_js_err;
-use crate::smile::{WasmDataFilter, WasmSmile, WasmSviSmile, WasmWeightingScheme};
+use crate::smile::{
+    WasmArbitrageScanConfig, WasmDataFilter, WasmSmile, WasmSviSmile, WasmWeightingScheme,
+};
 
 fn market_data_from_flat(
     flat: &[f64],
@@ -72,6 +74,16 @@ macro_rules! impl_wasm_surface_methods {
             pub fn diagnostics(&self) -> Result<WasmSurfaceDiagnostics, JsValue> {
                 self.inner
                     .diagnostics()
+                    .map(WasmSurfaceDiagnostics::from)
+                    .map_err(to_js_err)
+            }
+
+            pub fn diagnostics_with(
+                &self,
+                config: &WasmArbitrageScanConfig,
+            ) -> Result<WasmSurfaceDiagnostics, JsValue> {
+                self.inner
+                    .diagnostics_with(&config.inner())
                     .map(WasmSurfaceDiagnostics::from)
                     .map_err(to_js_err)
             }


### PR DESCRIPTION
## Summary
- Add `ArbitrageScanConfig` struct with `n_points`, `k_min`, `k_max` fields and model-specific defaults (`svi_default()`: 200/[-3,3], `sabr_default()`: 200/[-2,2])
- `SmileSection` trait gains `is_arbitrage_free_with(config)` with density-based default impl; existing `is_arbitrage_free()` becomes a default that delegates
- SVI, SABR, SsviSlice, EssviSlice override both methods with model-appropriate defaults; SplineSmile keeps its absolute-strike-space scan
- `VolSurface` trait gains `diagnostics_with(config)` — passes config through to per-smile butterfly checks, calendar checks unchanged
- Full Python + WASM binding exposure: `ArbitrageScanConfig` class, `is_arbitrage_free_with`, `diagnostics_with`
- 7 new Rust tests: default-matches-hardcoded, grid density sensitivity, range narrowing, validation (n<2, inverted range, NaN)

## Breaking Change Note
`diagnostics_with` is a new required method on `VolSurface`. No external implementors exist (0 downstream crates on crates.io).

## Changes
- `src/smile/mod.rs` — `ArbitrageScanConfig` struct + `SmileSection` trait additions
- `src/smile/svi.rs`, `src/smile/sabr.rs` — model impls
- `src/surface/ssvi.rs`, `src/surface/essvi.rs` — SsviSlice/EssviSlice + surface impls
- `src/surface/mod.rs`, `src/surface/piecewise.rs` — VolSurface trait + PiecewiseSurface
- `src/smile/arbitrage.rs` — 7 new tests
- `python/src/types.rs`, `python/src/smile.rs`, `python/src/surface.rs` — Python bindings
- `wasm/src/smile.rs`, `wasm/src/surface.rs`, `wasm/src/builder.rs` — WASM bindings

## Test plan
- [x] 881 Rust lib tests pass (874 + 7 new)
- [x] 63 WASM tests pass
- [x] 255 Python tests pass
- [x] Zero clippy warnings
- [x] All 5 roborev reviews addressed and closed

Closes #84