### PR TITLE
feat!: breaking API batch — v2.1.0 (#63 #64 #65 #66)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Production-ready volatility surface library for derivatives pricing"

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ assert!(report.is_free());
 
 // Surface-level diagnostics (butterfly + calendar)
 let diagnostics = surface.diagnostics()?;
-if !diagnostics.is_free {
+if !diagnostics.is_free() {
     for cal in &diagnostics.calendar_violations {
         println!("Calendar violation at K={}", cal.strike);
     }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ use volsurf::smile::{SviSmile, SmileSection};
 
 let smile = SviSmile::new(100.0, 1.0, 0.04, 0.4, -0.4, 0.0, 0.2)?;
 let report = smile.is_arbitrage_free()?;
-assert!(report.is_free);
+assert!(report.is_free());
 
 // Surface-level diagnostics (butterfly + calendar)
 let diagnostics = surface.diagnostics()?;

--- a/examples/basic_surface.rs
+++ b/examples/basic_surface.rs
@@ -112,7 +112,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     println!("Calendar violations: {}", diag.calendar_violations.len());
-    println!("Surface is arbitrage-free: {}", diag.is_free);
+    println!("Surface is arbitrage-free: {}", diag.is_free());
 
     Ok(())
 }

--- a/examples/essvi_slice.rs
+++ b/examples/essvi_slice.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Butterfly arbitrage check
     let report = slice.is_arbitrage_free()?;
     println!("=== Arbitrage Check ===");
-    println!("Butterfly arb-free: {}", report.is_free);
+    println!("Butterfly arb-free: {}", report.is_free());
     if !report.butterfly_violations.is_empty() {
         println!("Violations: {}", report.butterfly_violations.len());
     }

--- a/examples/essvi_surface.rs
+++ b/examples/essvi_surface.rs
@@ -174,7 +174,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Numerical calendar violations: {}",
         diag.calendar_violations.len()
     );
-    println!("Surface arb-free: {}", diag.is_free);
+    println!("Surface arb-free: {}", diag.is_free());
 
     // ---------------------------------------------------------------
     // 7. Compare eSSVI vs SSVI (fixed rho = rho_m)

--- a/examples/sabr_smile.rs
+++ b/examples/sabr_smile.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Surface diagnostics
     let diag = surface.diagnostics()?;
-    println!("\nSurface arb-free: {}", diag.is_free);
+    println!("\nSurface arb-free: {}", diag.is_free());
     println!("Calendar violations: {}", diag.calendar_violations.len());
 
     Ok(())

--- a/examples/sabr_smile.rs
+++ b/examples/sabr_smile.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "Butterfly violations: {}, arb-free: {}",
         report.butterfly_violations.len(),
-        report.is_free
+        report.is_free()
     );
 
     // ---------------------------------------------------------------

--- a/examples/smile_models.rs
+++ b/examples/smile_models.rs
@@ -89,12 +89,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "SVI:    {} butterfly violations, arb-free={}",
         svi_report.butterfly_violations.len(),
-        svi_report.is_free
+        svi_report.is_free()
     );
     println!(
         "Spline: {} butterfly violations, arb-free={}",
         spline_report.butterfly_violations.len(),
-        spline_report.is_free
+        spline_report.is_free()
     );
 
     // ---------------------------------------------------------------

--- a/examples/ssvi_surface.rs
+++ b/examples/ssvi_surface.rs
@@ -128,7 +128,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     println!("Calendar violations: {}", diag.calendar_violations.len());
-    println!("Surface arb-free: {}", diag.is_free);
+    println!("Surface arb-free: {}", diag.is_free());
 
     // Analytical calendar check (SSVI-specific)
     let cal_violations = surface.calendar_arb_analytical();

--- a/examples/ssvi_surface.rs
+++ b/examples/ssvi_surface.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "  Tenor {}: {} violations, arb-free={}",
             i + 1,
             report.butterfly_violations.len(),
-            report.is_free
+            report.is_free()
         );
     }
     println!("Calendar violations: {}", diag.calendar_violations.len());

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-python"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 publish = false
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "volsurf"
-version = "2.0.0"
+version = "2.1.0"
 requires-python = ">=3.9"
 dependencies = ["numpy>=1.24"]
 

--- a/python/src/smile.rs
+++ b/python/src/smile.rs
@@ -48,6 +48,11 @@ macro_rules! impl_smile_methods {
                     .into())
             }
 
+            #[getter]
+            fn model_name(&self) -> &str {
+                self.inner.model_name()
+            }
+
             fn to_json(&self) -> PyResult<String> {
                 serde_json::to_string(&self.inner).map_err(|e| PyValueError::new_err(e.to_string()))
             }

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -509,7 +509,7 @@ impl PySurfaceDiagnostics {
 impl From<SurfaceDiagnostics> for PySurfaceDiagnostics {
     fn from(d: SurfaceDiagnostics) -> Self {
         Self {
-            is_free: d.is_free,
+            is_free: d.is_free(),
             smile_reports_inner: d.smile_reports,
             calendar_violations_inner: d.calendar_violations,
         }

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -425,7 +425,7 @@ impl PyArbitrageReport {
 impl From<ArbitrageReport> for PyArbitrageReport {
     fn from(r: ArbitrageReport) -> Self {
         Self {
-            is_free: r.is_free,
+            is_free: r.is_free(),
             violations: r.butterfly_violations,
         }
     }

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -252,6 +252,11 @@ impl PySmile {
         self.inner.expiry()
     }
 
+    #[getter]
+    fn model_name(&self) -> &str {
+        self.inner.model_name()
+    }
+
     fn is_arbitrage_free(&self) -> PyResult<PyArbitrageReport> {
         Ok(self.inner.is_arbitrage_free().map_err(to_py_err)?.into())
     }
@@ -312,6 +317,10 @@ impl PySurface {
     fn smile_at(&self, expiry: f64) -> PyResult<PySmile> {
         let smile = self.inner.smile_at(Tenor(expiry)).map_err(to_py_err)?;
         Ok(PySmile { inner: smile })
+    }
+
+    fn tenors(&self) -> Vec<f64> {
+        self.inner.tenors().to_vec()
     }
 
     fn diagnostics(&self) -> PyResult<PySurfaceDiagnostics> {
@@ -389,6 +398,8 @@ impl From<&ButterflyViolation> for PyButterflyViolation {
 pub struct PyArbitrageReport {
     #[pyo3(get)]
     is_free: bool,
+    #[pyo3(get)]
+    expiry: f64,
     violations: Vec<ButterflyViolation>,
 }
 
@@ -426,6 +437,7 @@ impl From<ArbitrageReport> for PyArbitrageReport {
     fn from(r: ArbitrageReport) -> Self {
         Self {
             is_free: r.is_free(),
+            expiry: r.expiry,
             violations: r.butterfly_violations,
         }
     }

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -211,6 +211,9 @@ mod tests {
         fn expiry(&self) -> f64 {
             self.expiry
         }
+        fn model_name(&self) -> &'static str {
+            "Flat"
+        }
         fn density(&self, _: Strike) -> error::Result<f64> {
             unimplemented!()
         }
@@ -453,6 +456,9 @@ mod tests {
             }
             fn expiry(&self) -> f64 {
                 0.5
+            }
+            fn model_name(&self) -> &'static str {
+                "ZeroFwd"
             }
             fn density(&self, _: Strike) -> error::Result<f64> {
                 unimplemented!()

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -178,6 +178,9 @@ mod tests {
         ) -> error::Result<SurfaceDiagnostics> {
             unimplemented!()
         }
+        fn tenors(&self) -> &[f64] {
+            &[]
+        }
     }
 
     fn stub_surface() -> Arc<dyn VolSurface> {
@@ -241,6 +244,9 @@ mod tests {
             _: &crate::smile::ArbitrageScanConfig,
         ) -> error::Result<SurfaceDiagnostics> {
             unimplemented!()
+        }
+        fn tenors(&self) -> &[f64] {
+            &[]
         }
     }
 
@@ -483,6 +489,9 @@ mod tests {
                 _: &crate::smile::ArbitrageScanConfig,
             ) -> error::Result<SurfaceDiagnostics> {
                 unimplemented!()
+            }
+            fn tenors(&self) -> &[f64] {
+                &[]
             }
         }
 

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -153,7 +153,6 @@ impl LocalVol for DupireLocalVol {
 mod tests {
     use super::*;
     use crate::smile::SmileSection;
-    use crate::smile::arbitrage::ArbitrageReport;
     use crate::surface::arbitrage::SurfaceDiagnostics;
     use crate::types::{Strike, Tenor, Variance};
 

--- a/src/smile/arbitrage.rs
+++ b/src/smile/arbitrage.rs
@@ -9,51 +9,27 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Report on arbitrage-freeness of a smile or surface.
+/// Report on arbitrage-freeness of a smile at a specific expiry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArbitrageReport {
-    /// Whether the smile/surface is free of detected arbitrage.
-    pub is_free: bool,
+    /// Expiry (time to maturity) of the smile this report covers.
+    pub expiry: f64,
     /// Butterfly spread violations (negative density regions).
     pub butterfly_violations: Vec<ButterflyViolation>,
 }
 
 impl ArbitrageReport {
     /// Create a report indicating no arbitrage was found.
-    pub fn clean() -> Self {
+    pub fn clean(expiry: f64) -> Self {
         Self {
-            is_free: true,
+            expiry,
             butterfly_violations: Vec::new(),
         }
     }
 
-    /// Merge two reports, combining all violations.
-    ///
-    /// The merged report is arbitrage-free only if both source reports are free.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use volsurf::smile::{ArbitrageReport, ButterflyViolation};
-    ///
-    /// let clean = ArbitrageReport::clean();
-    /// let violated = ArbitrageReport {
-    ///     is_free: false,
-    ///     butterfly_violations: vec![ButterflyViolation {
-    ///         strike: 80.0, density: -0.001, magnitude: 0.001,
-    ///     }],
-    /// };
-    /// let merged = clean.merge(&violated);
-    /// assert!(!merged.is_free);
-    /// assert_eq!(merged.butterfly_violations.len(), 1);
-    /// ```
-    pub fn merge(&self, other: &ArbitrageReport) -> ArbitrageReport {
-        let mut violations = self.butterfly_violations.clone();
-        violations.extend(other.butterfly_violations.iter().cloned());
-        ArbitrageReport {
-            is_free: self.is_free && other.is_free,
-            butterfly_violations: violations,
-        }
+    /// Whether this smile is free of detected butterfly arbitrage.
+    pub fn is_free(&self) -> bool {
+        self.butterfly_violations.is_empty()
     }
 
     /// Return the worst (largest magnitude) butterfly violation, if any.
@@ -64,7 +40,7 @@ impl ArbitrageReport {
     /// use volsurf::smile::{ArbitrageReport, ButterflyViolation};
     ///
     /// let report = ArbitrageReport {
-    ///     is_free: false,
+    ///     expiry: 1.0,
     ///     butterfly_violations: vec![
     ///         ButterflyViolation { strike: 80.0, density: -0.001, magnitude: 0.001 },
     ///         ButterflyViolation { strike: 90.0, density: -0.005, magnitude: 0.005 },
@@ -104,99 +80,39 @@ mod tests {
         }
     }
 
-    fn violated_report() -> ArbitrageReport {
-        ArbitrageReport {
-            is_free: false,
-            butterfly_violations: vec![make_violation(80.0, -0.001), make_violation(85.0, -0.005)],
-        }
-    }
-
-    // ========== merge() ==========
-
     #[test]
-    fn merge_two_clean_reports() {
-        let a = ArbitrageReport::clean();
-        let b = ArbitrageReport::clean();
-        let merged = a.merge(&b);
-        assert!(merged.is_free);
-        assert!(merged.butterfly_violations.is_empty());
+    fn clean_report_is_free() {
+        let report = ArbitrageReport::clean(1.0);
+        assert!(report.is_free());
+        assert!(report.butterfly_violations.is_empty());
+        assert_eq!(report.expiry, 1.0);
     }
 
     #[test]
-    fn merge_clean_and_violated() {
-        let clean = ArbitrageReport::clean();
-        let bad = violated_report();
-        let merged = clean.merge(&bad);
-        assert!(!merged.is_free);
-        assert_eq!(merged.butterfly_violations.len(), 2);
-    }
+    fn is_free_computed_from_violations() {
+        let clean = ArbitrageReport {
+            expiry: 1.0,
+            butterfly_violations: vec![],
+        };
+        assert!(clean.is_free());
 
-    #[test]
-    fn merge_violated_and_clean() {
-        let bad = violated_report();
-        let clean = ArbitrageReport::clean();
-        let merged = bad.merge(&clean);
-        assert!(!merged.is_free);
-        assert_eq!(merged.butterfly_violations.len(), 2);
-    }
-
-    #[test]
-    fn merge_two_violated_combines_violations() {
-        let a = ArbitrageReport {
-            is_free: false,
+        let violated = ArbitrageReport {
+            expiry: 1.0,
             butterfly_violations: vec![make_violation(80.0, -0.001)],
         };
-        let b = ArbitrageReport {
-            is_free: false,
-            butterfly_violations: vec![make_violation(90.0, -0.003), make_violation(95.0, -0.002)],
-        };
-        let merged = a.merge(&b);
-        assert!(!merged.is_free);
-        assert_eq!(merged.butterfly_violations.len(), 3);
+        assert!(!violated.is_free());
     }
-
-    #[test]
-    fn merge_preserves_violation_data() {
-        let a = ArbitrageReport {
-            is_free: false,
-            butterfly_violations: vec![make_violation(80.0, -0.007)],
-        };
-        let b = ArbitrageReport::clean();
-        let merged = a.merge(&b);
-        assert_eq!(merged.butterfly_violations.len(), 1);
-        let v = &merged.butterfly_violations[0];
-        assert_eq!(v.strike, 80.0);
-        assert_eq!(v.density, -0.007);
-        assert_eq!(v.magnitude, 0.007);
-    }
-
-    #[test]
-    fn merge_not_free_empty_violations_with_clean() {
-        let report_a = ArbitrageReport {
-            is_free: false,
-            butterfly_violations: vec![],
-        };
-        let report_b = ArbitrageReport {
-            is_free: true,
-            butterfly_violations: vec![],
-        };
-        let merged = report_a.merge(&report_b);
-        assert!(!merged.is_free);
-        assert!(merged.butterfly_violations.is_empty());
-    }
-
-    // ========== worst_violation() ==========
 
     #[test]
     fn worst_violation_clean_report_returns_none() {
-        let clean = ArbitrageReport::clean();
+        let clean = ArbitrageReport::clean(1.0);
         assert!(clean.worst_violation().is_none());
     }
 
     #[test]
     fn worst_violation_single_violation() {
         let report = ArbitrageReport {
-            is_free: false,
+            expiry: 1.0,
             butterfly_violations: vec![make_violation(80.0, -0.003)],
         };
         let worst = report.worst_violation().unwrap();
@@ -207,7 +123,7 @@ mod tests {
     #[test]
     fn worst_violation_picks_largest_magnitude() {
         let report = ArbitrageReport {
-            is_free: false,
+            expiry: 1.0,
             butterfly_violations: vec![
                 make_violation(80.0, -0.001),
                 make_violation(85.0, -0.010),
@@ -222,7 +138,7 @@ mod tests {
     #[test]
     fn worst_violation_tied_magnitudes() {
         let report = ArbitrageReport {
-            is_free: false,
+            expiry: 1.0,
             butterfly_violations: vec![
                 ButterflyViolation {
                     strike: 90.0,
@@ -238,25 +154,20 @@ mod tests {
         };
         let worst = report.worst_violation().unwrap();
         assert!((worst.magnitude - 0.005).abs() < 1e-15);
-        // max_by with total_cmp returns last equal element
         assert_eq!(worst.strike, 110.0);
     }
 
-    // ========== SABR butterfly detection ==========
-
     #[test]
     fn sabr_extreme_nu_detects_violations() {
-        // Large nu produces wild smile curvature that creates negative density.
         use crate::smile::SabrSmile;
         let sabr = SabrSmile::new(100.0, 1.0, 0.3, 0.5, -0.5, 2.0).unwrap();
         let report = sabr.is_arbitrage_free().unwrap();
         assert!(
-            !report.is_free,
+            !report.is_free(),
             "extreme nu should produce butterfly violations"
         );
         assert!(!report.butterfly_violations.is_empty());
-        let worst = report.worst_violation().unwrap();
-        assert!(worst.magnitude > 0.0);
+        assert!(report.worst_violation().unwrap().magnitude > 0.0);
     }
 
     #[test]
@@ -264,33 +175,28 @@ mod tests {
         use crate::smile::SabrSmile;
         let sabr = SabrSmile::new(100.0, 1.0, 0.2, 0.5, -0.3, 0.3).unwrap();
         let report = sabr.is_arbitrage_free().unwrap();
-        assert!(report.is_free, "conservative SABR should be arb-free");
+        assert!(report.is_free(), "conservative SABR should be arb-free");
         assert!(report.worst_violation().is_none());
     }
 
-    // ========== SSVI butterfly detection ==========
-
     #[test]
     fn ssvi_extreme_params_detects_violations() {
-        // eta*(1+|rho|) = 3*(1+0.95) = 5.85 >> 2 => violations expected.
         use crate::surface::SsviSlice;
         let slice = SsviSlice::new(100.0, 1.0, -0.95, 3.0, 0.5, 0.16).unwrap();
         let report = slice.is_arbitrage_free().unwrap();
         assert!(
-            !report.is_free,
+            !report.is_free(),
             "extreme SSVI params should detect violations"
         );
-        let worst = report.worst_violation().unwrap();
-        assert!(worst.magnitude > 0.0);
+        assert!(report.worst_violation().unwrap().magnitude > 0.0);
     }
 
     #[test]
     fn ssvi_conservative_params_clean() {
-        // eta*(1+|rho|) = 0.5*(1+0.3) = 0.65 < 2 => clean.
         use crate::surface::SsviSlice;
         let slice = SsviSlice::new(100.0, 1.0, -0.3, 0.5, 0.5, 0.16).unwrap();
         let report = slice.is_arbitrage_free().unwrap();
-        assert!(report.is_free, "conservative SSVI should be arb-free");
+        assert!(report.is_free(), "conservative SSVI should be arb-free");
         assert!(report.worst_violation().is_none());
     }
 
@@ -304,7 +210,7 @@ mod tests {
         let config_report = svi
             .is_arbitrage_free_with(&ArbitrageScanConfig::svi_default())
             .unwrap();
-        assert_eq!(default_report.is_free, config_report.is_free);
+        assert_eq!(default_report.is_free(), config_report.is_free());
         assert_eq!(
             default_report.butterfly_violations.len(),
             config_report.butterfly_violations.len()
@@ -319,7 +225,7 @@ mod tests {
         let config_report = sabr
             .is_arbitrage_free_with(&ArbitrageScanConfig::sabr_default())
             .unwrap();
-        assert_eq!(default_report.is_free, config_report.is_free);
+        assert_eq!(default_report.is_free(), config_report.is_free());
         assert_eq!(
             default_report.butterfly_violations.len(),
             config_report.butterfly_violations.len()

--- a/src/smile/mod.rs
+++ b/src/smile/mod.rs
@@ -118,7 +118,7 @@ impl ArbitrageScanConfig {
 /// assert!((var.0 - vol.0 * vol.0 * smile.expiry()).abs() < 1e-12);
 ///
 /// let report = smile.is_arbitrage_free()?;
-/// assert!(report.is_free);
+/// assert!(report.is_free());
 /// # Ok::<(), volsurf::VolSurfError>(())
 /// ```
 pub trait SmileSection: Send + Sync + std::fmt::Debug {
@@ -223,7 +223,7 @@ pub trait SmileSection: Send + Sync + std::fmt::Debug {
             }
         }
         Ok(ArbitrageReport {
-            is_free: violations.is_empty(),
+            expiry: self.expiry(),
             butterfly_violations: violations,
         })
     }

--- a/src/smile/mod.rs
+++ b/src/smile/mod.rs
@@ -184,6 +184,9 @@ pub trait SmileSection: Send + Sync + std::fmt::Debug {
     /// Time to expiry T in years.
     fn expiry(&self) -> f64;
 
+    /// Human-readable model name (e.g. "SVI", "SABR", "CubicSpline").
+    fn model_name(&self) -> &'static str;
+
     /// Check whether this smile is free of butterfly arbitrage.
     ///
     /// Uses model-specific defaults for scan grid. Override this or

--- a/src/smile/sabr.rs
+++ b/src/smile/sabr.rs
@@ -617,7 +617,7 @@ impl SmileSection for SabrSmile {
         }
 
         Ok(ArbitrageReport {
-            is_free: violations.is_empty(),
+            expiry: self.expiry,
             butterfly_violations: violations,
         })
     }
@@ -1468,7 +1468,7 @@ mod tests {
         let s = make_equity_smile();
         let report = s.is_arbitrage_free().unwrap();
         assert!(
-            report.is_free,
+            report.is_free(),
             "well-behaved params should be arb-free, got {} violations",
             report.butterfly_violations.len()
         );
@@ -1480,7 +1480,7 @@ mod tests {
         let s = SabrSmile::new(F, T, 0.20, 1.0, -0.25, 0.30).unwrap();
         let report = s.is_arbitrage_free().unwrap();
         assert!(
-            report.is_free,
+            report.is_free(),
             "β=1 with moderate params should be arb-free"
         );
     }
@@ -1490,7 +1490,7 @@ mod tests {
         let s = SabrSmile::new(F, T, 10.0, 0.0, -0.2, 0.30).unwrap();
         let report = s.is_arbitrage_free().unwrap();
         assert!(
-            report.is_free,
+            report.is_free(),
             "β=0 with moderate params should be arb-free"
         );
     }
@@ -1500,7 +1500,7 @@ mod tests {
         // nu=0 (CEV) should always be arb-free
         let s = SabrSmile::new(F, T, EQ_ALPHA, BETA, RHO, 0.0).unwrap();
         let report = s.is_arbitrage_free().unwrap();
-        assert!(report.is_free, "CEV (ν=0) should be arb-free");
+        assert!(report.is_free(), "CEV (ν=0) should be arb-free");
     }
 
     #[test]
@@ -1511,7 +1511,7 @@ mod tests {
         let report = s.is_arbitrage_free().unwrap();
         // With nu=5.0, the approximation likely produces negative densities
         // (if not, this is still a valid test — just confirms well-behaved)
-        if !report.is_free {
+        if !report.is_free() {
             for v in &report.butterfly_violations {
                 assert!(v.density < 0.0);
                 assert!(v.magnitude > 0.0);
@@ -1525,7 +1525,7 @@ mod tests {
         // High nu provokes violations; verify field structure if detected
         let s = SabrSmile::new(F, T, EQ_ALPHA, BETA, -0.5, 5.0).unwrap();
         let report = s.is_arbitrage_free().unwrap();
-        if !report.is_free {
+        if !report.is_free() {
             let v = &report.butterfly_violations[0];
             assert!(v.strike > 0.0, "violation strike should be positive");
             assert!(v.density < 0.0, "violation density should be negative");
@@ -1549,7 +1549,7 @@ mod tests {
         let v = boxed.vol(Strike(F)).unwrap();
         assert!(v.0 > 0.0);
         let report = boxed.is_arbitrage_free().unwrap();
-        assert!(report.is_free);
+        assert!(report.is_free());
     }
 
     // ========================================================================

--- a/src/smile/sabr.rs
+++ b/src/smile/sabr.rs
@@ -580,6 +580,10 @@ impl SmileSection for SabrSmile {
         self.expiry
     }
 
+    fn model_name(&self) -> &'static str {
+        "SABR"
+    }
+
     /// Check butterfly arbitrage by scanning risk-neutral density.
     ///
     /// Evaluates density on a grid of 200 points over k ∈ \[−2, 2\].

--- a/src/smile/spline.rs
+++ b/src/smile/spline.rs
@@ -298,7 +298,7 @@ impl SmileSection for SplineSmile {
         }
 
         Ok(ArbitrageReport {
-            is_free: violations.is_empty(),
+            expiry: self.expiry,
             butterfly_violations: violations,
         })
     }
@@ -574,7 +574,7 @@ mod tests {
 
         let report = smile.is_arbitrage_free().unwrap();
         assert!(
-            report.is_free,
+            report.is_free(),
             "convex smile should be arb-free, got {} violations",
             report.butterfly_violations.len()
         );

--- a/src/smile/spline.rs
+++ b/src/smile/spline.rs
@@ -276,6 +276,10 @@ impl SmileSection for SplineSmile {
         self.expiry
     }
 
+    fn model_name(&self) -> &'static str {
+        "CubicSpline"
+    }
+
     fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
         // Number of grid points for density-based arbitrage scan.
         let n_samples = 200;

--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -700,7 +700,7 @@ impl SmileSection for SviSmile {
         }
 
         Ok(ArbitrageReport {
-            is_free: violations.is_empty(),
+            expiry: self.expiry,
             butterfly_violations: violations,
         })
     }
@@ -1083,7 +1083,7 @@ mod tests {
     fn arb_free_params_clean_report() {
         let smile = make_arb_free_smile();
         let report = smile.is_arbitrage_free().unwrap();
-        assert!(report.is_free, "expected arb-free report");
+        assert!(report.is_free(), "expected arb-free report");
         assert!(report.butterfly_violations.is_empty());
     }
 
@@ -1092,7 +1092,7 @@ mod tests {
         // Aggressive slope with small curvature: g(k) goes negative in wings
         let smile = SviSmile::new(100.0, 1.0, 0.001, 0.8, -0.7, 0.0, 0.05).unwrap();
         let report = smile.is_arbitrage_free().unwrap();
-        assert!(!report.is_free, "expected violations");
+        assert!(!report.is_free(), "expected violations");
         assert!(
             !report.butterfly_violations.is_empty(),
             "expected non-empty violations"
@@ -1129,7 +1129,7 @@ mod tests {
     fn flat_smile_is_arb_free() {
         let smile = SviSmile::new(100.0, 1.0, 0.04, 0.0, 0.0, 0.0, 0.1).unwrap();
         let report = smile.is_arbitrage_free().unwrap();
-        assert!(report.is_free);
+        assert!(report.is_free());
     }
 
     #[test]

--- a/src/smile/svi.rs
+++ b/src/smile/svi.rs
@@ -662,6 +662,10 @@ impl SmileSection for SviSmile {
         self.expiry
     }
 
+    fn model_name(&self) -> &'static str {
+        "SVI"
+    }
+
     /// Check butterfly arbitrage by scanning the Gatheral g-function.
     ///
     /// Evaluates g(k) on a grid of 200 points over k ∈ \[−3, 3\].

--- a/src/surface/arbitrage.rs
+++ b/src/surface/arbitrage.rs
@@ -13,8 +13,13 @@ pub struct SurfaceDiagnostics {
     pub smile_reports: Vec<ArbitrageReport>,
     /// Calendar spread violations (variance decreasing in time).
     pub calendar_violations: Vec<CalendarViolation>,
-    /// Whether the entire surface is arbitrage-free.
-    pub is_free: bool,
+}
+
+impl SurfaceDiagnostics {
+    /// Whether the entire surface is free of detected arbitrage.
+    pub fn is_free(&self) -> bool {
+        self.smile_reports.iter().all(|r| r.is_free()) && self.calendar_violations.is_empty()
+    }
 }
 
 /// A calendar spread arbitrage violation at a specific (tenor, strike) point.
@@ -42,9 +47,8 @@ mod tests {
         let diag = SurfaceDiagnostics {
             smile_reports: vec![],
             calendar_violations: vec![],
-            is_free: true,
         };
-        assert!(diag.is_free);
+        assert!(diag.is_free());
         assert!(diag.smile_reports.is_empty());
         assert!(diag.calendar_violations.is_empty());
     }
@@ -62,9 +66,8 @@ mod tests {
         let diag = SurfaceDiagnostics {
             smile_reports: vec![report],
             calendar_violations: vec![],
-            is_free: false,
         };
-        assert!(!diag.is_free);
+        assert!(!diag.is_free());
         assert_eq!(diag.smile_reports.len(), 1);
         assert!(!diag.smile_reports[0].is_free());
     }
@@ -85,9 +88,8 @@ mod tests {
         let diag = SurfaceDiagnostics {
             smile_reports: vec![clean_report],
             calendar_violations: vec![violation],
-            is_free: false,
         };
-        assert!(!diag.is_free);
+        assert!(!diag.is_free());
         assert_eq!(diag.calendar_violations.len(), 1);
         assert_eq!(diag.calendar_violations[0].strike, 100.0);
         assert!(
@@ -115,9 +117,8 @@ mod tests {
         let diag = SurfaceDiagnostics {
             smile_reports: vec![butterfly_report],
             calendar_violations: vec![cal_violation],
-            is_free: false,
         };
-        assert!(!diag.is_free);
+        assert!(!diag.is_free());
         assert!(!diag.smile_reports.is_empty());
         assert!(!diag.calendar_violations.is_empty());
     }
@@ -146,13 +147,12 @@ mod tests {
                 variance_short: 0.07,
                 variance_long: 0.065,
             }],
-            is_free: false,
         };
 
         let json = serde_json::to_string(&diag).unwrap();
         let roundtrip: SurfaceDiagnostics = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(roundtrip.is_free, diag.is_free);
+        assert_eq!(roundtrip.is_free(), diag.is_free());
         assert_eq!(roundtrip.smile_reports.len(), diag.smile_reports.len());
         assert_eq!(
             roundtrip.calendar_violations.len(),

--- a/src/surface/arbitrage.rs
+++ b/src/surface/arbitrage.rs
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn diagnostics_with_butterfly_violations_not_free() {
         let report = ArbitrageReport {
-            is_free: false,
+            expiry: 1.0,
             butterfly_violations: vec![ButterflyViolation {
                 strike: 90.0,
                 density: -0.001,
@@ -66,7 +66,7 @@ mod tests {
         };
         assert!(!diag.is_free);
         assert_eq!(diag.smile_reports.len(), 1);
-        assert!(!diag.smile_reports[0].is_free);
+        assert!(!diag.smile_reports[0].is_free());
     }
 
     #[test]
@@ -79,7 +79,7 @@ mod tests {
             variance_long: 0.05,
         };
         let clean_report = ArbitrageReport {
-            is_free: true,
+            expiry: 1.0,
             butterfly_violations: vec![],
         };
         let diag = SurfaceDiagnostics {
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn diagnostics_mixed_violations_not_free() {
         let butterfly_report = ArbitrageReport {
-            is_free: false,
+            expiry: 1.0,
             butterfly_violations: vec![ButterflyViolation {
                 strike: 85.0,
                 density: -0.002,
@@ -127,11 +127,11 @@ mod tests {
         let diag = SurfaceDiagnostics {
             smile_reports: vec![
                 ArbitrageReport {
-                    is_free: true,
+                    expiry: 0.5,
                     butterfly_violations: vec![],
                 },
                 ArbitrageReport {
-                    is_free: false,
+                    expiry: 1.0,
                     butterfly_violations: vec![ButterflyViolation {
                         strike: 95.0,
                         density: -0.0005,

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -1108,7 +1108,7 @@ impl VolSurface for EssviSurface {
             }
         }
 
-        let is_free = smile_reports.iter().all(|r| r.is_free) && calendar_violations.is_empty();
+        let is_free = smile_reports.iter().all(|r| r.is_free()) && calendar_violations.is_empty();
 
         Ok(SurfaceDiagnostics {
             smile_reports,
@@ -1252,7 +1252,7 @@ mod tests {
     fn arb_free_conservative_params() {
         let s = equity_slice();
         let report = s.is_arbitrage_free().unwrap();
-        assert!(report.is_free);
+        assert!(report.is_free());
         assert!(report.butterfly_violations.is_empty());
     }
 
@@ -1261,7 +1261,7 @@ mod tests {
         // eta * (1 + |rho|) = 3.0 * 1.95 = 5.85 >> 2
         let s = EssviSlice::new(100.0, 1.0, -0.95, 3.0, 0.5, 0.16).unwrap();
         let report = s.is_arbitrage_free().unwrap();
-        assert!(!report.is_free);
+        assert!(!report.is_free());
         assert!(!report.butterfly_violations.is_empty());
     }
 

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -1117,6 +1117,10 @@ impl VolSurface for EssviSurface {
             calendar_violations,
         })
     }
+
+    fn tenors(&self) -> &[f64] {
+        &self.tenors
+    }
 }
 
 #[cfg(test)]

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -1108,12 +1108,9 @@ impl VolSurface for EssviSurface {
             }
         }
 
-        let is_free = smile_reports.iter().all(|r| r.is_free()) && calendar_violations.is_empty();
-
         Ok(SurfaceDiagnostics {
             smile_reports,
             calendar_violations,
-            is_free,
         })
     }
 }
@@ -2048,7 +2045,7 @@ mod tests {
         let s = equity_surface();
         let diag = s.diagnostics().unwrap();
         assert_eq!(diag.smile_reports.len(), 4);
-        assert!(diag.is_free, "conservative params should be arb-free");
+        assert!(diag.is_free(), "conservative params should be arb-free");
         assert!(diag.calendar_violations.is_empty());
     }
 
@@ -2057,7 +2054,7 @@ mod tests {
         let s = two_tenor_surface();
         let diag = s.diagnostics().unwrap();
         assert_eq!(diag.smile_reports.len(), 2);
-        assert!(diag.is_free);
+        assert!(diag.is_free());
     }
 
     #[test]
@@ -2325,7 +2322,7 @@ mod tests {
         let calibrated = EssviSurface::calibrate(&market_data, &tenors, &forwards).unwrap();
         let diag = calibrated.diagnostics().unwrap();
         assert!(
-            diag.is_free,
+            diag.is_free(),
             "calibrated eSSVI from conservative input should be arb-free"
         );
     }

--- a/src/surface/essvi.rs
+++ b/src/surface/essvi.rs
@@ -213,6 +213,10 @@ impl SmileSection for EssviSlice {
         self.0.expiry()
     }
 
+    fn model_name(&self) -> &'static str {
+        "eSSVI"
+    }
+
     fn is_arbitrage_free(&self) -> error::Result<ArbitrageReport> {
         self.0.is_arbitrage_free()
     }

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -97,4 +97,7 @@ pub trait VolSurface: Send + Sync + std::fmt::Debug {
     /// Passes `config` through to per-smile `is_arbitrage_free_with()` calls.
     /// Calendar spread checks use the same hardcoded grid as `diagnostics()`.
     fn diagnostics_with(&self, config: &ArbitrageScanConfig) -> error::Result<SurfaceDiagnostics>;
+
+    /// The tenor grid (expiries in years) that this surface covers.
+    fn tenors(&self) -> &[f64];
 }

--- a/src/surface/piecewise.rs
+++ b/src/surface/piecewise.rs
@@ -209,12 +209,9 @@ impl PiecewiseSurface {
             }
         }
 
-        let is_free = smile_reports.iter().all(|r| r.is_free()) && calendar_violations.is_empty();
-
         Ok(SurfaceDiagnostics {
             smile_reports,
             calendar_violations,
-            is_free,
         })
     }
 }
@@ -550,7 +547,7 @@ mod tests {
 
         let diag = surface.diagnostics().unwrap();
         assert!(
-            diag.is_free,
+            diag.is_free(),
             "surface with increasing vol should be arb-free, but got {} calendar violations",
             diag.calendar_violations.len()
         );
@@ -564,7 +561,7 @@ mod tests {
         let surface = PiecewiseSurface::new(vec![0.5, 1.0], vec![s1, s2]).unwrap();
 
         let diag = surface.diagnostics().unwrap();
-        assert!(!diag.is_free, "inverted surface should have violations");
+        assert!(!diag.is_free(), "inverted surface should have violations");
         assert!(
             !diag.calendar_violations.is_empty(),
             "should have calendar violations"

--- a/src/surface/piecewise.rs
+++ b/src/surface/piecewise.rs
@@ -333,6 +333,10 @@ impl VolSurface for PiecewiseSurface {
         }
         self.diagnostics_from_smile_reports(smile_reports)
     }
+
+    fn tenors(&self) -> &[f64] {
+        &self.tenors
+    }
 }
 
 #[cfg(test)]

--- a/src/surface/piecewise.rs
+++ b/src/surface/piecewise.rs
@@ -209,7 +209,7 @@ impl PiecewiseSurface {
             }
         }
 
-        let is_free = smile_reports.iter().all(|r| r.is_free) && calendar_violations.is_empty();
+        let is_free = smile_reports.iter().all(|r| r.is_free()) && calendar_violations.is_empty();
 
         Ok(SurfaceDiagnostics {
             smile_reports,

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -942,6 +942,10 @@ impl SmileSection for SsviSlice {
         self.expiry
     }
 
+    fn model_name(&self) -> &'static str {
+        "SSVI"
+    }
+
     /// Analytical risk-neutral density via the Gatheral g-function.
     ///
     /// ```text

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -696,7 +696,7 @@ impl VolSurface for SsviSurface {
             }
         }
 
-        let is_free = smile_reports.iter().all(|r| r.is_free) && calendar_violations.is_empty();
+        let is_free = smile_reports.iter().all(|r| r.is_free()) && calendar_violations.is_empty();
 
         Ok(SurfaceDiagnostics {
             smile_reports,
@@ -1009,7 +1009,7 @@ impl SmileSection for SsviSlice {
         }
 
         Ok(ArbitrageReport {
-            is_free: violations.is_empty(),
+            expiry: self.expiry,
             butterfly_violations: violations,
         })
     }
@@ -2028,7 +2028,7 @@ mod tests {
         assert!(diag.is_free, "conservative SSVI should be arb-free");
         assert!(diag.calendar_violations.is_empty());
         assert_eq!(diag.smile_reports.len(), 4);
-        assert!(diag.smile_reports.iter().all(|r| r.is_free));
+        assert!(diag.smile_reports.iter().all(|r| r.is_free()));
     }
 
     #[test]
@@ -2046,7 +2046,7 @@ mod tests {
         let diag = s.diagnostics().unwrap();
         assert!(!diag.is_free);
         // At least one tenor should have butterfly violations
-        assert!(diag.smile_reports.iter().any(|r| !r.is_free));
+        assert!(diag.smile_reports.iter().any(|r| !r.is_free()));
     }
 
     #[test]
@@ -2370,7 +2370,7 @@ mod tests {
         let s = equity_slice();
         let report = s.is_arbitrage_free().unwrap();
         assert!(
-            report.is_free,
+            report.is_free(),
             "conservative SSVI params should be arb-free"
         );
         assert!(report.butterfly_violations.is_empty());
@@ -2382,7 +2382,7 @@ mod tests {
         let s = SsviSlice::new(100.0, 1.0, -0.95, 3.0, 0.5, 0.16).unwrap();
         let report = s.is_arbitrage_free().unwrap();
         assert!(
-            !report.is_free,
+            !report.is_free(),
             "extreme SSVI params should detect butterfly violations"
         );
         assert!(!report.butterfly_violations.is_empty());

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -701,6 +701,10 @@ impl VolSurface for SsviSurface {
             calendar_violations,
         })
     }
+
+    fn tenors(&self) -> &[f64] {
+        &self.tenors
+    }
 }
 
 pub(crate) fn strike_grid(forward: f64, n: usize) -> Vec<f64> {

--- a/src/surface/ssvi.rs
+++ b/src/surface/ssvi.rs
@@ -696,12 +696,9 @@ impl VolSurface for SsviSurface {
             }
         }
 
-        let is_free = smile_reports.iter().all(|r| r.is_free()) && calendar_violations.is_empty();
-
         Ok(SurfaceDiagnostics {
             smile_reports,
             calendar_violations,
-            is_free,
         })
     }
 }
@@ -1823,7 +1820,7 @@ mod tests {
         let calibrated = SsviSurface::calibrate(&market_data, &tenors, &forwards).unwrap();
         let diag = calibrated.diagnostics().unwrap();
         assert!(
-            diag.is_free,
+            diag.is_free(),
             "calibrated SSVI from conservative input should be arb-free"
         );
     }
@@ -2025,7 +2022,7 @@ mod tests {
         // eta * (1 + |rho|) = 0.5 * 1.3 = 0.65 < 2, and thetas strictly increasing.
         let s = equity_surface();
         let diag = s.diagnostics().unwrap();
-        assert!(diag.is_free, "conservative SSVI should be arb-free");
+        assert!(diag.is_free(), "conservative SSVI should be arb-free");
         assert!(diag.calendar_violations.is_empty());
         assert_eq!(diag.smile_reports.len(), 4);
         assert!(diag.smile_reports.iter().all(|r| r.is_free()));
@@ -2044,7 +2041,7 @@ mod tests {
         )
         .unwrap();
         let diag = s.diagnostics().unwrap();
-        assert!(!diag.is_free);
+        assert!(!diag.is_free());
         // At least one tenor should have butterfly violations
         assert!(diag.smile_reports.iter().any(|r| !r.is_free()));
     }
@@ -2170,7 +2167,7 @@ mod tests {
 
         let diag = surface.diagnostics().unwrap();
         assert!(
-            !diag.is_free,
+            !diag.is_free(),
             "inverted SSVI slices should have calendar violations"
         );
         assert!(

--- a/tests/hendriks_martini_2019.rs
+++ b/tests/hendriks_martini_2019.rs
@@ -269,7 +269,7 @@ fn thm_4_1_full_diagnostics_paper_params() {
         "paper params should have no calendar violations, found {}",
         diag.calendar_violations.len()
     );
-    assert!(diag.is_free, "paper params should be fully arb-free");
+    assert!(diag.is_free(), "paper params should be fully arb-free");
 }
 
 // ── Proposition 3.5: two-slice discrete no-arb ──────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -355,7 +355,7 @@ fn calendar_violation_detected_for_inverted_surface() -> Result<(), Box<dyn std:
     )?;
 
     let diag = surface.diagnostics()?;
-    assert!(!diag.is_free, "Inverted surface should not be arb-free");
+    assert!(!diag.is_free(), "Inverted surface should not be arb-free");
     assert!(
         !diag.calendar_violations.is_empty(),
         "Should have calendar violations"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -290,7 +290,7 @@ fn butterfly_arb_free_params_report_clean() -> Result<(), Box<dyn std::error::Er
     let smile = SviSmile::new(100.0, 1.0, 0.04, 0.4, -0.3, 0.0, 0.5)?;
     let report = smile.is_arbitrage_free()?;
     assert!(
-        report.is_free,
+        report.is_free(),
         "Clean params should be arb-free, got {} violations",
         report.butterfly_violations.len()
     );
@@ -309,7 +309,7 @@ fn butterfly_violation_detected_via_diagnostics() -> Result<(), Box<dyn std::err
     // With such extreme params, butterfly violations are likely
     // (though not 100% guaranteed for every param set).
     // If this particular set is arb-free, that's fine — skip assertion.
-    if !report.is_free {
+    if !report.is_free() {
         assert!(
             !report.butterfly_violations.is_empty(),
             "Non-free report should have violations"
@@ -823,7 +823,7 @@ fn sabr_butterfly_clean_params() -> Result<(), Box<dyn std::error::Error>> {
     let smile = SabrSmile::new(100.0, 1.0, 0.20, 0.5, -0.30, 0.30)?;
     let report = smile.is_arbitrage_free()?;
     assert!(
-        report.is_free,
+        report.is_free(),
         "Well-behaved SABR should be arb-free, got {} violations",
         report.butterfly_violations.len()
     );

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-wasm"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "WebAssembly bindings for volsurf"

--- a/wasm/src/arbitrage.rs
+++ b/wasm/src/arbitrage.rs
@@ -45,6 +45,11 @@ impl WasmArbitrageReport {
         self.inner.is_free()
     }
 
+    #[wasm_bindgen(getter)]
+    pub fn expiry(&self) -> f64 {
+        self.inner.expiry
+    }
+
     pub fn butterfly_violations(&self) -> Vec<WasmButterflyViolation> {
         self.inner
             .butterfly_violations

--- a/wasm/src/arbitrage.rs
+++ b/wasm/src/arbitrage.rs
@@ -114,7 +114,7 @@ impl From<SurfaceDiagnostics> for WasmSurfaceDiagnostics {
 impl WasmSurfaceDiagnostics {
     #[wasm_bindgen(getter)]
     pub fn is_arbitrage_free(&self) -> bool {
-        self.inner.is_free
+        self.inner.is_free()
     }
 
     pub fn smile_reports(&self) -> Vec<WasmArbitrageReport> {

--- a/wasm/src/arbitrage.rs
+++ b/wasm/src/arbitrage.rs
@@ -42,7 +42,7 @@ impl From<ArbitrageReport> for WasmArbitrageReport {
 impl WasmArbitrageReport {
     #[wasm_bindgen(getter)]
     pub fn is_arbitrage_free(&self) -> bool {
-        self.inner.is_free
+        self.inner.is_free()
     }
 
     pub fn butterfly_violations(&self) -> Vec<WasmButterflyViolation> {

--- a/wasm/src/builder.rs
+++ b/wasm/src/builder.rs
@@ -168,6 +168,10 @@ impl WasmPiecewiseSurface {
         Ok(WasmSmile::new(smile))
     }
 
+    pub fn tenors(&self) -> Vec<f64> {
+        self.inner.tenors().to_vec()
+    }
+
     pub fn diagnostics(&self) -> Result<WasmSurfaceDiagnostics, JsValue> {
         self.inner
             .diagnostics()

--- a/wasm/src/smile.rs
+++ b/wasm/src/smile.rs
@@ -38,6 +38,11 @@ macro_rules! impl_wasm_smile_methods {
                 self.inner.expiry()
             }
 
+            #[wasm_bindgen(getter)]
+            pub fn model_name(&self) -> String {
+                self.inner.model_name().to_string()
+            }
+
             pub fn is_arbitrage_free(&self) -> Result<WasmArbitrageReport, JsValue> {
                 self.inner
                     .is_arbitrage_free()

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -373,7 +373,7 @@ fn too_few_points_rejected() {
 
 #[wasm_bindgen_test]
 fn version_returns_string() {
-    assert_eq!(version(), "2.0.0");
+    assert_eq!(version(), "2.1.0");
 }
 
 // ── is_arbitrage_free on smiles ──

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -386,7 +386,7 @@ fn svi_is_arbitrage_free() {
     assert!(report.butterfly_violations().is_empty());
 
     let json = report.to_json().unwrap();
-    assert!(json.contains("\"is_free\""));
+    assert!(json.contains("\"expiry\""));
     assert!(json.contains("\"butterfly_violations\""));
 }
 
@@ -538,7 +538,8 @@ fn svi_butterfly_violations_detected() {
     }
 
     let json = report.to_json().unwrap();
-    assert!(json.contains("\"is_free\":false"));
+    assert!(json.contains("\"butterfly_violations\""));
+    assert!(!report.is_arbitrage_free());
 }
 
 // ── WasmSmile is_arbitrage_free (via smile_at) ──

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -248,6 +248,9 @@ fn builder_svi_surface() {
 
     let var = surface.black_variance(0.5, 100.0).unwrap();
     assert!((var - vol * vol * 0.5).abs() < 1e-10);
+
+    let tenors = surface.tenors();
+    assert_eq!(tenors.len(), 2);
 }
 
 #[wasm_bindgen_test]
@@ -386,8 +389,21 @@ fn svi_is_arbitrage_free() {
     assert!(report.butterfly_violations().is_empty());
 
     let json = report.to_json().unwrap();
-    assert!(json.contains("\"expiry\""));
+    assert!(json.contains("\"expiry\":1.0"));
     assert!(json.contains("\"butterfly_violations\""));
+    assert_eq!(report.expiry(), 1.0);
+}
+
+#[wasm_bindgen_test]
+fn svi_model_name() {
+    let smile = WasmSviSmile::new(100.0, 1.0, 0.04, 0.1, -0.5, 0.0, 0.3).unwrap();
+    assert_eq!(smile.model_name(), "SVI");
+}
+
+#[wasm_bindgen_test]
+fn sabr_model_name() {
+    let smile = WasmSabrSmile::new(100.0, 1.0, 0.2, 0.5, -0.3, 0.4).unwrap();
+    assert_eq!(smile.model_name(), "SABR");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary

Batched all 4 remaining breaking API changes into a single release (v2.1.0).

### Breaking Changes

- **ArbitrageReport** (#65, #66): `is_free` is now a computed method (not stored field). New `expiry: f64` field. `merge()` removed. `clean()` takes expiry param. Serde output no longer includes `is_free`.
- **SurfaceDiagnostics** (#66): `is_free` is now a computed method. Logic consolidated from 3 duplicate sites.
- **SmileSection** (#64): New required `model_name() -> &'static str` method. Returns "SVI", "SABR", "CubicSpline", "SSVI", "eSSVI".
- **VolSurface** (#63): New required `tenors() -> &[f64]` method. Enables generic code over `Box<dyn VolSurface>`.

### Semver Note

v2.1.0 (pragmatic) — 0 downstream crates on crates.io. Breaking changes documented in commit messages with `feat!:` prefix.

## Changes
- 30 files changed, 213 insertions, 216 deletions (net -3)
- Core: ArbitrageReport, SurfaceDiagnostics restructured; 2 trait methods added
- Bindings: Python + WASM updated for all 4 changes
- Tests: 65 WASM tests (was 63), all Rust tests updated

## Test plan
- [x] 877 Rust lib + 5 bench + 17 doc + 40 integration + 13 proptest + 15 hendriks + 20 doctest = 987 Rust tests
- [x] 65 WASM tests pass
- [x] 255 Python tests pass
- [x] Zero clippy warnings
- [x] All 6 roborev reviews addressed and closed

Closes #63, closes #64, closes #65, closes #66