### PR TITLE
feat: BoundaryLocalVol Dupire small-time boundary adapter — v2.2.0 (PAN-25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-06
+
+### Added
+
+- `BoundaryLocalVol<L: LocalVol>` — opt-in adapter that smooths the Dupire small-time boundary: a query at `t ≤ floor` evaluates the inner local vol at `t = floor` (keeping total variance `w = σ²·T` away from the singular `1/w`, `k²/w²` terms in the Gatheral denominator as `T → 0`); `t > floor` delegates exactly to the strict path (PAN-25)
+- `DupireLocalVol::with_boundary()` — wraps a `DupireLocalVol` in a `BoundaryLocalVol` whose `floor` defaults to the finite-difference `bump_size`
+- `BoundaryLocalVol` and `DupireLocalVol` re-exported at the crate root
+
 ## [2.0.0] "Type-Safe Inputs" - 2026-03-13
 
 ### Changed
@@ -130,7 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `logging` Cargo feature for optional tracing instrumentation
 - Examples: `basic_surface`, `smile_models`, `implied_vol`
 
-[Unreleased]: https://github.com/volsurf-rs/volsurf/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/volsurf-rs/volsurf/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/volsurf-rs/volsurf/compare/v2.1.0...v2.2.0
 [2.0.0]: https://github.com/volsurf-rs/volsurf/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/volsurf-rs/volsurf/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/volsurf-rs/volsurf/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DupireLocalVol::with_boundary()` — wraps a `DupireLocalVol` in a `BoundaryLocalVol` whose `floor` defaults to the finite-difference `bump_size`
 - `BoundaryLocalVol` and `DupireLocalVol` re-exported at the crate root
 
+## [2.1.0] "API Polish" - 2026-03-25
+
+### Added
+
+- `SmileSection::model_name()` — returns the model identifier (`"SVI"`, `"SABR"`, `"CubicSpline"`, `"SSVI"`, `"eSSVI"`)
+- `VolSurface::tenors()` — accessor returning the surface's tenors as `&[f64]`
+- `expiry` field on `ArbitrageReport` for per-tenor attribution
+- Configurable arbitrage scanning via `ArbitrageScanConfig`: `SmileSection::is_arbitrage_free_with(config)` and `VolSurface::diagnostics_with(config)`
+- Configurable calibration: `DataFilter`, `WeightingScheme`, and warm-starting via `calibrate_with_config` on smile models
+- `Clone` + `PartialEq` on `VolSurfError`
+
+### Changed
+
+- **BREAKING**: `is_arbitrage_free()` is now computed on demand from the smile/surface rather than stored at construction
+- SVI warm-start falls back to grid search when the seeded optimization diverges
+
 ## [2.0.0] "Type-Safe Inputs" - 2026-03-13
 
 ### Changed
@@ -140,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/volsurf-rs/volsurf/compare/v2.2.0...HEAD
 [2.2.0]: https://github.com/volsurf-rs/volsurf/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/volsurf-rs/volsurf/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/volsurf-rs/volsurf/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/volsurf-rs/volsurf/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/volsurf-rs/volsurf/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Production-ready volatility surface library for derivatives pricing"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-python"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 publish = false
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use calibration::{DataFilter, WeightingScheme, apply_filter};
 #[doc(inline)]
 pub use error::{Result, VolSurfError};
 #[doc(inline)]
-pub use local_vol::LocalVol;
+pub use local_vol::{BoundaryLocalVol, DupireLocalVol, LocalVol};
 #[doc(inline)]
 pub use smile::SmileSection;
 #[doc(inline)]

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -600,4 +600,136 @@ mod tests {
         let v = lv.local_vol(Tenor(0.015), Strike(100.0)).unwrap();
         assert!((v.0 - sigma).abs() < 1e-10, "short T: got {}", v.0);
     }
+
+    // ----- BoundaryLocalVol (PAN-25) -----
+
+    // SVI PiecewiseSurface fixture shared by the boundary tests below — same
+    // arb-free parameters as atm_matches_simplified_formula / svi_analytical_otm.
+    fn svi_surface() -> Arc<dyn VolSurface> {
+        use crate::smile::SviSmile;
+        use crate::surface::PiecewiseSurface;
+
+        let fwd = 100.0;
+        let (t1, t2) = (0.5, 1.5);
+        let (a1, a2) = (0.02, 0.06);
+        let (b, rho, m, sigma) = (0.3, -0.3, 0.0, 0.15);
+        let s1 = Box::new(SviSmile::new(fwd, t1, a1, b, rho, m, sigma).unwrap())
+            as Box<dyn SmileSection>;
+        let s2 = Box::new(SviSmile::new(fwd, t2, a2, b, rho, m, sigma).unwrap())
+            as Box<dyn SmileSection>;
+        Arc::new(PiecewiseSurface::new(vec![t1, t2], vec![s1, s2]).unwrap())
+    }
+
+    // Flat surface: sigma_loc == sigma exactly, so the clamped boundary value at
+    // t = 0, 0 < t < floor, and t == floor must all return sigma.
+    #[test]
+    fn boundary_flat_exact_at_and_below_floor() {
+        let sigma = 0.25;
+        let adapter = DupireLocalVol::new(flat_surface(sigma)).with_boundary();
+
+        // t = 0 is rejected by the strict path but rescued to floor here.
+        let v = adapter.local_vol(Tenor(0.0), Strike(100.0)).unwrap();
+        assert!((v.0 - sigma).abs() < 1e-10, "t=0: got {}", v.0);
+
+        // 0 < t < floor (= 0.01)
+        let v = adapter.local_vol(Tenor(0.005), Strike(120.0)).unwrap();
+        assert!((v.0 - sigma).abs() < 1e-10, "0<t<floor: got {}", v.0);
+
+        // exactly at the floor
+        let v = adapter.local_vol(Tenor(0.01), Strike(80.0)).unwrap();
+        assert!((v.0 - sigma).abs() < 1e-10, "t=floor: got {}", v.0);
+    }
+
+    // For t > floor the adapter must delegate to DupireLocalVol::local_vol with
+    // the original tenor: same code path, so the result is bit-identical.
+    #[test]
+    fn boundary_delegates_bit_identical_above_floor() {
+        let surf = svi_surface();
+        let raw = DupireLocalVol::new(surf.clone());
+        let adapter = DupireLocalVol::new(surf).with_boundary();
+
+        for (t, k) in [(0.5, 100.0), (1.0, 110.0), (1.2, 90.0)] {
+            let r = raw.local_vol(Tenor(t), Strike(k)).unwrap();
+            let a = adapter.local_vol(Tenor(t), Strike(k)).unwrap();
+            assert_eq!(r.0, a.0, "delegation drift at t={t}, K={k}");
+        }
+    }
+
+    // The boundary the adapter exists to fix: an OTM query at t=0 errors on the
+    // strict path (InvalidInput) but succeeds on the adapter (clamped to floor).
+    // NOTE: on the arb-free flat-extrapolation fixture a NumericalError baseline
+    // is not reproducible (w scales t/t1, so smaller t is more stable); the
+    // t=0 -> InvalidInput rescue is the real boundary (requirements FR-1/FR-5).
+    #[test]
+    fn boundary_succeeds_where_raw_errors_at_t0() {
+        let surf = svi_surface();
+        let raw = DupireLocalVol::new(surf.clone());
+        let adapter = DupireLocalVol::new(surf).with_boundary();
+        let k = Strike(110.0); // OTM
+
+        assert!(
+            raw.local_vol(Tenor(0.0), k).is_err(),
+            "strict path should reject t=0"
+        );
+        assert!(
+            adapter.local_vol(Tenor(0.0), k).is_ok(),
+            "adapter should rescue t=0 via the floor"
+        );
+    }
+
+    // Strike stays strict; t < 0 / NaN / inf still rejected (t = 0 is allowed).
+    #[test]
+    fn boundary_rejects_invalid_inputs() {
+        let a = DupireLocalVol::new(flat_surface(0.2)).with_boundary();
+        assert!(matches!(
+            a.local_vol(Tenor(-1.0), Strike(100.0)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            a.local_vol(Tenor(f64::NAN), Strike(100.0)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            a.local_vol(Tenor(f64::INFINITY), Strike(100.0)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            a.local_vol(Tenor(0.5), Strike(0.0)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            a.local_vol(Tenor(0.5), Strike(f64::NAN)),
+            Err(VolSurfError::InvalidInput { .. })
+        ));
+    }
+
+    // with_boundary()'s floor is the Dupire bump_size (single source of truth):
+    // default 0.01, and a custom bump propagates.
+    #[test]
+    fn boundary_floor_defaults_to_bump_size() {
+        let a = DupireLocalVol::new(flat_surface(0.2)).with_boundary();
+        assert_eq!(a.floor, 0.01);
+
+        let a2 = DupireLocalVol::new(flat_surface(0.2))
+            .with_bump_size(0.005)
+            .unwrap()
+            .with_boundary();
+        assert_eq!(a2.floor, 0.005);
+    }
+
+    // BoundaryLocalVol::new rejects a non-positive / non-finite floor, honors a
+    // valid custom floor, and into_inner() returns the wrapped LocalVol.
+    #[test]
+    fn boundary_new_validates_floor_and_into_inner() {
+        for bad in [0.0, -0.1, f64::NAN, f64::INFINITY] {
+            assert!(
+                BoundaryLocalVol::new(DupireLocalVol::new(stub_surface()), bad).is_err(),
+                "floor {bad} should be rejected"
+            );
+        }
+
+        let b = BoundaryLocalVol::new(DupireLocalVol::new(stub_surface()), 0.02).unwrap();
+        assert_eq!(b.floor, 0.02, "custom floor honored");
+        let _inner: DupireLocalVol = b.into_inner();
+    }
 }

--- a/src/local_vol/dupire.rs
+++ b/src/local_vol/dupire.rs
@@ -19,7 +19,7 @@ use crate::conventions::log_moneyness;
 use crate::error::{self, VolSurfError};
 use crate::surface::VolSurface;
 use crate::types::{Strike, Tenor, Vol};
-use crate::validate::validate_positive;
+use crate::validate::{validate_non_negative, validate_positive};
 
 use super::LocalVol;
 
@@ -60,6 +60,23 @@ impl DupireLocalVol {
         validate_positive(bump_size, "bump_size")?;
         self.bump_size = bump_size;
         Ok(self)
+    }
+
+    /// Wrap this Dupire local vol in a [`BoundaryLocalVol`] that handles the
+    /// small-time boundary, using the finite-difference [`bump_size`](Self::with_bump_size)
+    /// as the floor.
+    ///
+    /// For a query at `t ≤ bump_size` the wrapper evaluates `σ_loc` at
+    /// `t = bump_size` instead of erroring; for `t > bump_size` it delegates to
+    /// the strict [`local_vol`](LocalVol::local_vol) unchanged. This is the
+    /// opt-in way to keep total variance `w = σ²·T` bounded away from the
+    /// singular `1/w` and `k²/w²` terms in the Gatheral (2006) denominator as
+    /// `T → 0` (see [`BoundaryLocalVol`]).
+    pub fn with_boundary(self) -> BoundaryLocalVol<Self> {
+        // `bump_size` is validated positive on construction (default 0.01,
+        // `with_bump_size` rejects non-positive), so it is a valid floor.
+        let floor = self.bump_size;
+        BoundaryLocalVol { inner: self, floor }
     }
 }
 
@@ -146,6 +163,78 @@ impl LocalVol for DupireLocalVol {
         }
 
         Ok(Vol(v_local.sqrt()))
+    }
+}
+
+/// A [`LocalVol`] adapter that smooths the small-time boundary.
+///
+/// The Dupire formula (Gatheral 2006, Eq. 1.10) divides by total implied
+/// variance `w = σ²·T`; its denominator carries `−1/w` and `k²/w²` terms that
+/// are ill-conditioned as `T → 0`, and the strict
+/// [`DupireLocalVol`] rejects `T = 0` outright. Consumers that evaluate local
+/// vol at the calendar-time boundary — a backward PDE march whose last step is
+/// `t = 0`, or a Monte-Carlo path's first step — therefore have to clamp their
+/// queries away from zero by hand.
+///
+/// `BoundaryLocalVol` encapsulates that clamp: for a query at `T ≤ floor` it
+/// evaluates the inner local vol at `T = floor`; for `T > floor` it delegates
+/// **exactly** to the inner implementation. Evaluating at `floor` keeps `w`
+/// bounded away from zero, sidestepping the singular denominator entirely. On a
+/// flat surface the result is exact (`σ_loc ≡ σ`); on a smile it is an `O(floor)`
+/// short-maturity extrapolation.
+///
+/// This is opt-in and composes around any `L: LocalVol` (mirroring the
+/// `std::io::BufReader<R>` / `Take<R>` adapter pattern); the strict
+/// [`DupireLocalVol::local_vol`] path is left unchanged. The usual entry point is
+/// [`DupireLocalVol::with_boundary`], which sets `floor` to the Dupire bump size.
+///
+/// # References
+/// - Gatheral, J. "The Volatility Surface: A Practitioner's Guide" (2006), Ch. 2
+#[derive(Debug, Clone)]
+pub struct BoundaryLocalVol<L: LocalVol> {
+    inner: L,
+    floor: f64,
+}
+
+impl<L: LocalVol> BoundaryLocalVol<L> {
+    /// Wrap `inner`, treating any query at `expiry ≤ floor` as a query at
+    /// `expiry = floor`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VolSurfError::InvalidInput`] if `floor` is zero, negative, NaN,
+    /// or infinite.
+    pub fn new(inner: L, floor: f64) -> error::Result<Self> {
+        validate_positive(floor, "floor")?;
+        Ok(Self { inner, floor })
+    }
+
+    /// Consume the wrapper and return the inner [`LocalVol`].
+    pub fn into_inner(self) -> L {
+        self.inner
+    }
+}
+
+impl<L: LocalVol> LocalVol for BoundaryLocalVol<L> {
+    /// Local volatility with the small-time boundary handled.
+    ///
+    /// For `expiry ≤ floor` the inner local vol is evaluated at
+    /// `expiry = floor`; for `expiry > floor` the call delegates unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VolSurfError::InvalidInput`] if `strike` is non-positive or
+    /// `expiry` is negative, NaN, or infinite (`expiry = 0` is valid and maps to
+    /// `floor`). Otherwise propagates any error from the inner implementation.
+    fn local_vol(&self, expiry: Tenor, strike: Strike) -> error::Result<Vol> {
+        validate_positive(strike.0, "strike")?;
+        validate_non_negative(expiry.0, "expiry")?;
+
+        if expiry.0 <= self.floor {
+            self.inner.local_vol(Tenor(self.floor), strike)
+        } else {
+            self.inner.local_vol(expiry, strike)
+        }
     }
 }
 

--- a/src/local_vol/mod.rs
+++ b/src/local_vol/mod.rs
@@ -14,7 +14,7 @@
 
 pub mod dupire;
 
-pub use dupire::DupireLocalVol;
+pub use dupire::{BoundaryLocalVol, DupireLocalVol};
 
 use crate::error;
 use crate::types::{Strike, Tenor, Vol};

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-wasm"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "WebAssembly bindings for volsurf"


### PR DESCRIPTION
## Summary

Adds an opt-in **`BoundaryLocalVol<L: LocalVol>`** adapter that smooths the Dupire small-time boundary: a query at `t ≤ floor` evaluates the inner local vol at `t = floor`; `t > floor` delegates **exactly** to the strict path. `floor` defaults to the Dupire `bump_size` (single source of truth). The strict `DupireLocalVol::local_vol` is unchanged — this is purely additive (minor bump to **v2.2.0**).

This encapsulates, inside volsurf, the `t=0` / small-`t` boundary handling that downstream **numeraire** consumers currently hand-roll as a `t ≥ bump + ε` clamp. Unblocks **PAN-21**.

Resolves **PAN-25**.

## Commits

- `feat`: `BoundaryLocalVol<L>` + `DupireLocalVol::with_boundary()` + crate-root re-exports + docs
- `test`: 6 boundary / delegation / invalid-input tests
- `docs`: CHANGELOG `[2.2.0]` + version bump 2.1.0→2.2.0 (core + python + wasm, lockstep)
- `docs`: backfill missing `[2.1.0]` CHANGELOG section

## Design

- **Wrapper type over inherent method** — generic `BoundaryLocalVol<L>` implementing `LocalVol`, mirroring `std::io::Take<R>` / `BufReader<R>`. Keeps the strict path untouched; opt-in is a type you choose.
- **Clamp-to-floor over QuantLib's adaptive-`dt`** — QuantLib floors the FD *step*, not the query *time*, and shares the `1/w` singularity at literal `t=0`. Clamping the query time to `floor` evaluates where total variance `w = σ²·T` is bounded away from zero, which is strictly more robust at the boundary our consumers hit (backward PDE last step / MC step 0).

## Quality

- `cargo test --lib`: **883 passed / 0 failed**
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo build --release`: clean
- roborev branch review: no outstanding actionable findings (per-commit "no tests" Medium resolved by the test commit; pre-existing `[2.1.0]` changelog gap backfilled).

## Note

The "OTM small-`t` → `NumericalError` on raw" baseline from the issue is **not reproducible** on the arb-free SVI flat-extrapolation fixture (`w` scales `t/t₁`, so smaller `t` is *more* stable). The adapter's real win is the `t=0 → InvalidInput` rescue; tests assert that honestly and document the discrepancy.

## Downstream (PAN-21, separate)

Pin `volsurf = "2.2"`, swap the clamp dance for `.with_boundary()`, delete the `DUPIRE_DEFAULT_BUMP_SIZE` mirror constant, verify identical pricing within MC noise.

---

📋 Recommend **squash merge** (matches repo history).