### PR TITLE
feat: WASM binding parity — implied vol, conventions, local vol (PAN-28) — v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-06
+
+### Added
+
+- WASM binding parity with the Python crate (PAN-28):
+  - Implied vol: `blackPrice`/`normalPrice`/`displacedPrice` undiscounted pricing fns, `WasmBlackImpliedVol`/`WasmNormalImpliedVol` (static `compute`) and `WasmDisplacedImpliedVol` (instance, with `beta`) for Black/Normal/displaced-diffusion IV extraction, and a `WasmOptionType` (`Call`/`Put`) enum
+  - Conventions: `logMoneyness`, `moneyness`, `forwardPrice` helpers
+  - Local vol: `WasmDupireLocalVol` and `WasmBoundaryLocalVol` (the v2.2 PAN-25 small-time boundary adapter), reachable from any surface via `dupireLocalVol(bumpSize?)` / `dupireLocalVolWithBoundary(bumpSize?)` on `WasmSsviSurface`, `WasmEssviSurface`, and `WasmPiecewiseSurface`
+  - WASM smoke tests covering price→IV round-trips, convention known-values, flat-surface `σ_loc ≡ σ`, and the `t = 0` boundary rescue
+- Lockstep version bump of all three crates (core, `volsurf-python`, `volsurf-wasm`) to 2.3.0; core `src/` is unchanged in this release
+
 ## [2.2.0] - 2026-06-06
 
 ### Added
@@ -154,7 +165,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `logging` Cargo feature for optional tracing instrumentation
 - Examples: `basic_surface`, `smile_models`, `implied_vol`
 
-[Unreleased]: https://github.com/volsurf-rs/volsurf/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/volsurf-rs/volsurf/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/volsurf-rs/volsurf/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/volsurf-rs/volsurf/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/volsurf-rs/volsurf/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/volsurf-rs/volsurf/compare/v1.0.0...v2.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Production-ready volatility surface library for derivatives pricing"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-python"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 publish = false
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volsurf-wasm"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "WebAssembly bindings for volsurf"

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -33,6 +33,41 @@ Output in `wasm/pkg/`: `.wasm` binary, `.js` loader, `.d.ts` type definitions, `
 
 ## API
 
+### Implied Vol
+
+Undiscounted pricing and implied-vol extraction (Jäckel rational approximations).
+`WasmOptionType` is a `{ Call, Put }` enum passed into every pricer.
+
+```typescript
+import { WasmOptionType, blackPrice, WasmBlackImpliedVol,
+         normalPrice, WasmNormalImpliedVol,
+         displacedPrice, WasmDisplacedImpliedVol } from "volsurf-wasm";
+
+// Black (lognormal)
+const price = blackPrice(100, 100, 0.20, 1.0, WasmOptionType.Call);
+const iv = WasmBlackImpliedVol.compute(price, 100, 100, 1.0, WasmOptionType.Call);  // ~0.20
+
+// Normal (Bachelier) — vol is in price units
+const np = normalPrice(100, 100, 20.0, 1.0, WasmOptionType.Put);
+const niv = WasmNormalImpliedVol.compute(np, 100, 100, 1.0, WasmOptionType.Put);   // ~20.0
+
+// Displaced diffusion (interpolates normal ↔ Black); instance carries beta ∈ [0, 1]
+const dp = displacedPrice(100, 100, 0.20, 1.0, 0.5, WasmOptionType.Call);
+const calc = new WasmDisplacedImpliedVol(0.5);
+calc.beta;                                              // 0.5
+const div = calc.compute(dp, 100, 100, 1.0, WasmOptionType.Call);  // ~0.20
+```
+
+### Conventions
+
+```typescript
+import { logMoneyness, moneyness, forwardPrice } from "volsurf-wasm";
+
+logMoneyness(100, 100);        // ~0      (k = ln(K / F))
+moneyness(120, 100);           // ~1.2    (m = K / F)
+forwardPrice(100, 0.05, 0, 1); // ~105.127 (F = S·exp((r − q)·T))
+```
+
 ### Smiles
 
 **WasmSviSmile** — SVI parametric model (Gatheral 2004)
@@ -102,6 +137,23 @@ const surface = builder.build();  // returns WasmPiecewiseSurface
 
 surface.blackVol(0.5, 100.0)
 surface.blackVariance(0.5, 100.0)
+```
+
+### Local Vol
+
+Dupire local volatility (Gatheral 2006, Eq. 1.10) composed over any surface.
+Because WASM has no unified surface type, obtain a local-vol object by calling a
+method on the surface — available on `WasmSsviSurface`, `WasmEssviSurface`, and
+`WasmPiecewiseSurface`. `bumpSize` is optional (defaults to 0.01).
+
+```typescript
+const lv = surface.dupireLocalVol();        // WasmDupireLocalVol (optional bumpSize)
+lv.localVol(0.5, 100.0);                     // σ_loc at (expiry, strike)
+
+// Boundary adapter (v2.2 / PAN-25): a query at t ≤ floor (the bump size) is
+// evaluated at t = floor, rescuing the t → 0 singularity of the strict path.
+const bdy = surface.dupireLocalVolWithBoundary();  // WasmBoundaryLocalVol
+bdy.localVol(0.0, 100.0);                    // succeeds where dupireLocalVol throws at t = 0
 ```
 
 ### Error Handling

--- a/wasm/src/builder.rs
+++ b/wasm/src/builder.rs
@@ -188,4 +188,18 @@ impl WasmPiecewiseSurface {
             .map(WasmSurfaceDiagnostics::from)
             .map_err(to_js_err)
     }
+
+    pub fn dupire_local_vol(
+        &self,
+        bump_size: Option<f64>,
+    ) -> Result<crate::local_vol::WasmDupireLocalVol, JsValue> {
+        crate::local_vol::WasmDupireLocalVol::from_arc(Arc::clone(&self.inner), bump_size)
+    }
+
+    pub fn dupire_local_vol_with_boundary(
+        &self,
+        bump_size: Option<f64>,
+    ) -> Result<crate::local_vol::WasmBoundaryLocalVol, JsValue> {
+        crate::local_vol::WasmBoundaryLocalVol::from_arc(Arc::clone(&self.inner), bump_size)
+    }
 }

--- a/wasm/src/implied.rs
+++ b/wasm/src/implied.rs
@@ -1,0 +1,181 @@
+use volsurf::OptionType;
+use wasm_bindgen::prelude::*;
+
+use crate::error::to_js_err;
+
+/// Option type: call or put. Mirrors [`volsurf::OptionType`].
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub enum WasmOptionType {
+    Call,
+    Put,
+}
+
+impl From<WasmOptionType> for OptionType {
+    fn from(v: WasmOptionType) -> Self {
+        match v {
+            WasmOptionType::Call => OptionType::Call,
+            WasmOptionType::Put => OptionType::Put,
+        }
+    }
+}
+
+impl From<OptionType> for WasmOptionType {
+    fn from(v: OptionType) -> Self {
+        match v {
+            OptionType::Call => WasmOptionType::Call,
+            OptionType::Put => WasmOptionType::Put,
+        }
+    }
+}
+
+/// Undiscounted Black (lognormal) option price.
+#[wasm_bindgen]
+pub fn black_price(
+    forward: f64,
+    strike: f64,
+    vol: f64,
+    expiry: f64,
+    option_type: WasmOptionType,
+) -> Result<f64, JsValue> {
+    volsurf::implied::black_price(forward, strike, vol, expiry, option_type.into())
+        .map_err(to_js_err)
+}
+
+/// Undiscounted Bachelier (normal) option price.
+#[wasm_bindgen]
+pub fn normal_price(
+    forward: f64,
+    strike: f64,
+    vol: f64,
+    expiry: f64,
+    option_type: WasmOptionType,
+) -> Result<f64, JsValue> {
+    volsurf::implied::normal_price(forward, strike, vol, expiry, option_type.into())
+        .map_err(to_js_err)
+}
+
+/// Undiscounted displaced-diffusion option price.
+#[wasm_bindgen]
+pub fn displaced_price(
+    forward: f64,
+    strike: f64,
+    vol: f64,
+    expiry: f64,
+    beta: f64,
+    option_type: WasmOptionType,
+) -> Result<f64, JsValue> {
+    volsurf::implied::displaced_price(forward, strike, vol, expiry, beta, option_type.into())
+        .map_err(to_js_err)
+}
+
+/// Black (lognormal) implied volatility extraction via Jäckel's algorithm.
+#[wasm_bindgen]
+pub struct WasmBlackImpliedVol;
+
+#[wasm_bindgen]
+impl WasmBlackImpliedVol {
+    /// Extract Black implied volatility from an undiscounted option price.
+    pub fn compute(
+        option_price: f64,
+        forward: f64,
+        strike: f64,
+        expiry: f64,
+        option_type: WasmOptionType,
+    ) -> Result<f64, JsValue> {
+        volsurf::implied::BlackImpliedVol::compute(
+            option_price,
+            forward,
+            strike,
+            expiry,
+            option_type.into(),
+        )
+        .map(|v| v.0)
+        .map_err(to_js_err)
+    }
+}
+
+/// Bachelier (normal) implied volatility extraction.
+#[wasm_bindgen]
+pub struct WasmNormalImpliedVol;
+
+#[wasm_bindgen]
+impl WasmNormalImpliedVol {
+    /// Extract normal (Bachelier) implied volatility from an undiscounted option price.
+    pub fn compute(
+        option_price: f64,
+        forward: f64,
+        strike: f64,
+        expiry: f64,
+        option_type: WasmOptionType,
+    ) -> Result<f64, JsValue> {
+        volsurf::implied::NormalImpliedVol::compute(
+            option_price,
+            forward,
+            strike,
+            expiry,
+            option_type.into(),
+        )
+        .map(|v| v.0)
+        .map_err(to_js_err)
+    }
+}
+
+/// Displaced-diffusion implied volatility extraction (interpolates normal ↔ Black).
+#[wasm_bindgen]
+pub struct WasmDisplacedImpliedVol {
+    inner: volsurf::implied::DisplacedImpliedVol,
+}
+
+#[wasm_bindgen]
+impl WasmDisplacedImpliedVol {
+    /// Construct with displacement parameter `beta` ∈ [0, 1].
+    #[wasm_bindgen(constructor)]
+    pub fn new(beta: f64) -> Result<WasmDisplacedImpliedVol, JsValue> {
+        let inner = volsurf::implied::DisplacedImpliedVol::new(beta).map_err(to_js_err)?;
+        Ok(Self { inner })
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn beta(&self) -> f64 {
+        self.inner.beta()
+    }
+
+    /// Extract displaced-diffusion implied volatility from an undiscounted option price.
+    pub fn compute(
+        &self,
+        option_price: f64,
+        forward: f64,
+        strike: f64,
+        expiry: f64,
+        option_type: WasmOptionType,
+    ) -> Result<f64, JsValue> {
+        self.inner
+            .compute(option_price, forward, strike, expiry, option_type.into())
+            .map(|v| v.0)
+            .map_err(to_js_err)
+    }
+}
+
+/// Log-moneyness: k = ln(K / F).
+#[wasm_bindgen]
+pub fn log_moneyness(strike: f64, forward: f64) -> Result<f64, JsValue> {
+    volsurf::conventions::log_moneyness(strike, forward).map_err(to_js_err)
+}
+
+/// Simple moneyness: m = K / F.
+#[wasm_bindgen]
+pub fn moneyness(strike: f64, forward: f64) -> Result<f64, JsValue> {
+    volsurf::conventions::moneyness(strike, forward).map_err(to_js_err)
+}
+
+/// Forward price from spot: F = S · exp((r − q) · T).
+#[wasm_bindgen]
+pub fn forward_price(
+    spot: f64,
+    rate: f64,
+    dividend_yield: f64,
+    expiry: f64,
+) -> Result<f64, JsValue> {
+    volsurf::conventions::forward_price(spot, rate, dividend_yield, expiry).map_err(to_js_err)
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -4,6 +4,7 @@ mod arbitrage;
 mod builder;
 mod error;
 mod implied;
+mod local_vol;
 mod smile;
 mod surface;
 
@@ -15,6 +16,7 @@ pub use implied::{
     WasmBlackImpliedVol, WasmDisplacedImpliedVol, WasmNormalImpliedVol, WasmOptionType,
     black_price, displaced_price, forward_price, log_moneyness, moneyness, normal_price,
 };
+pub use local_vol::{WasmBoundaryLocalVol, WasmDupireLocalVol};
 pub use smile::{
     WasmArbitrageScanConfig, WasmDataFilter, WasmSabrSmile, WasmSmile, WasmSviSmile,
     WasmWeightingScheme, weighting_model_default, weighting_uniform, weighting_vega,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 mod arbitrage;
 mod builder;
 mod error;
+mod implied;
 mod smile;
 mod surface;
 
@@ -10,6 +11,10 @@ pub use arbitrage::{
     WasmArbitrageReport, WasmButterflyViolation, WasmCalendarViolation, WasmSurfaceDiagnostics,
 };
 pub use builder::{WasmPiecewiseSurface, WasmSurfaceBuilder};
+pub use implied::{
+    WasmBlackImpliedVol, WasmDisplacedImpliedVol, WasmNormalImpliedVol, WasmOptionType,
+    black_price, displaced_price, forward_price, log_moneyness, moneyness, normal_price,
+};
 pub use smile::{
     WasmArbitrageScanConfig, WasmDataFilter, WasmSabrSmile, WasmSmile, WasmSviSmile,
     WasmWeightingScheme, weighting_model_default, weighting_uniform, weighting_vega,

--- a/wasm/src/local_vol.rs
+++ b/wasm/src/local_vol.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use volsurf::local_vol::{BoundaryLocalVol, DupireLocalVol, LocalVol};
+use volsurf::{Strike, Tenor, VolSurface};
+use wasm_bindgen::prelude::*;
+
+use crate::error::to_js_err;
+
+/// Build a [`DupireLocalVol`] from a surface, applying an optional bump size.
+///
+/// Shared seam used by both `WasmDupireLocalVol::from_arc` and
+/// `WasmBoundaryLocalVol::from_arc`, and by the per-surface `dupire_local_vol*`
+/// methods (which is why it takes an `Arc<dyn VolSurface>` and is not itself
+/// `#[wasm_bindgen]`-exported).
+fn dupire_from_arc(
+    surface: Arc<dyn VolSurface>,
+    bump_size: Option<f64>,
+) -> Result<DupireLocalVol, JsValue> {
+    let mut lv = DupireLocalVol::new(surface);
+    if let Some(h) = bump_size {
+        lv = lv.with_bump_size(h).map_err(to_js_err)?;
+    }
+    Ok(lv)
+}
+
+/// Dupire local volatility derived from an implied vol surface.
+#[wasm_bindgen]
+pub struct WasmDupireLocalVol {
+    inner: DupireLocalVol,
+}
+
+impl WasmDupireLocalVol {
+    /// Construct from a shared surface, with an optional finite-difference bump
+    /// size (defaults to 1% when `None`). `pub(crate)` because it takes an
+    /// `Arc<dyn VolSurface>`, which is not a wasm-bindgen-able type.
+    pub(crate) fn from_arc(
+        surface: Arc<dyn VolSurface>,
+        bump_size: Option<f64>,
+    ) -> Result<Self, JsValue> {
+        Ok(Self {
+            inner: dupire_from_arc(surface, bump_size)?,
+        })
+    }
+}
+
+#[wasm_bindgen]
+impl WasmDupireLocalVol {
+    /// Local volatility σ_loc at (expiry, strike).
+    pub fn local_vol(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
+        self.inner
+            .local_vol(Tenor(expiry), Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
+    }
+}
+
+/// Dupire local volatility with the small-time boundary handled (v2.2 / PAN-25).
+///
+/// For `expiry ≤ floor` (the Dupire bump size) it evaluates at `expiry = floor`,
+/// rescuing the otherwise-rejected `t = 0`; for `expiry > floor` it delegates
+/// bit-identically to [`WasmDupireLocalVol`].
+#[wasm_bindgen]
+pub struct WasmBoundaryLocalVol {
+    inner: BoundaryLocalVol<DupireLocalVol>,
+}
+
+impl WasmBoundaryLocalVol {
+    /// Construct from a shared surface, wrapping the Dupire local vol in the
+    /// boundary adapter via [`DupireLocalVol::with_boundary`].
+    pub(crate) fn from_arc(
+        surface: Arc<dyn VolSurface>,
+        bump_size: Option<f64>,
+    ) -> Result<Self, JsValue> {
+        Ok(Self {
+            inner: dupire_from_arc(surface, bump_size)?.with_boundary(),
+        })
+    }
+}
+
+#[wasm_bindgen]
+impl WasmBoundaryLocalVol {
+    /// Local volatility σ_loc at (expiry, strike), with the small-time boundary
+    /// handled (`expiry = 0` is valid and maps to the floor).
+    pub fn local_vol(&self, expiry: f64, strike: f64) -> Result<f64, JsValue> {
+        self.inner
+            .local_vol(Tenor(expiry), Strike(strike))
+            .map(|v| v.0)
+            .map_err(to_js_err)
+    }
+}

--- a/wasm/src/surface.rs
+++ b/wasm/src/surface.rs
@@ -1,7 +1,11 @@
+use std::sync::Arc;
+
 use volsurf::VolSurface;
 use volsurf::surface::{EssviSurface, PerTenorFit, SsviSurface};
 use volsurf::{Strike, Tenor};
 use wasm_bindgen::prelude::*;
+
+use crate::local_vol::{WasmBoundaryLocalVol, WasmDupireLocalVol};
 
 use crate::arbitrage::WasmSurfaceDiagnostics;
 use crate::error::to_js_err;
@@ -125,6 +129,22 @@ macro_rules! impl_wasm_surface_methods {
                     <$inner>::calibrate_with_config(&market_data, &tenors, &forwards, &f, &w)
                         .map_err(to_js_err)?;
                 Ok(Self { inner })
+            }
+
+            pub fn dupire_local_vol(
+                &self,
+                bump_size: Option<f64>,
+            ) -> Result<WasmDupireLocalVol, JsValue> {
+                let surface: Arc<dyn VolSurface> = Arc::new(self.inner.clone());
+                WasmDupireLocalVol::from_arc(surface, bump_size)
+            }
+
+            pub fn dupire_local_vol_with_boundary(
+                &self,
+                bump_size: Option<f64>,
+            ) -> Result<WasmBoundaryLocalVol, JsValue> {
+                let surface: Arc<dyn VolSurface> = Arc::new(self.inner.clone());
+                WasmBoundaryLocalVol::from_arc(surface, bump_size)
             }
         }
     };

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -376,7 +376,7 @@ fn too_few_points_rejected() {
 
 #[wasm_bindgen_test]
 fn version_returns_string() {
-    assert_eq!(version(), "2.1.0");
+    assert_eq!(version(), "2.2.0");
 }
 
 // ── is_arbitrage_free on smiles ──
@@ -811,4 +811,184 @@ fn builder_with_weighting() {
     builder.add_tenor(0.25, strikes, vols).unwrap();
     let surface = builder.build().unwrap();
     assert!(surface.black_vol(0.25, 100.0).unwrap() > 0.0);
+}
+
+// ── Implied vol: price → IV round-trips (mirrors python/tests/test_implied.py) ──
+// NOTE: these smoke tests execute on the HOST via the rlib crate-type
+// (`cargo test -p volsurf-wasm`); #[wasm_bindgen_test] degrades to a plain test
+// off-wasm, so no wasm runtime / wasm-pack is required (see PAN-28 R-3).
+
+#[wasm_bindgen_test]
+fn black_iv_round_trip_call() {
+    let (f, k, t, sigma) = (100.0, 100.0, 1.0, 0.20);
+    let price = black_price(f, k, sigma, t, WasmOptionType::Call).unwrap();
+    let iv = WasmBlackImpliedVol::compute(price, f, k, t, WasmOptionType::Call).unwrap();
+    assert!((iv - sigma).abs() < 1e-12, "black call iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn black_iv_round_trip_put() {
+    let (f, k, t, sigma) = (100.0, 100.0, 1.0, 0.20);
+    let price = black_price(f, k, sigma, t, WasmOptionType::Put).unwrap();
+    let iv = WasmBlackImpliedVol::compute(price, f, k, t, WasmOptionType::Put).unwrap();
+    assert!((iv - sigma).abs() < 1e-12, "black put iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn normal_iv_round_trip_call() {
+    // normal vol is in price units, so sigma = 20.0
+    let (f, k, t, sigma) = (100.0, 100.0, 1.0, 20.0);
+    let price = normal_price(f, k, sigma, t, WasmOptionType::Call).unwrap();
+    let iv = WasmNormalImpliedVol::compute(price, f, k, t, WasmOptionType::Call).unwrap();
+    assert!((iv - sigma).abs() < 1e-10, "normal call iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn normal_iv_round_trip_put() {
+    let (f, k, t, sigma) = (100.0, 100.0, 1.0, 20.0);
+    let price = normal_price(f, k, sigma, t, WasmOptionType::Put).unwrap();
+    let iv = WasmNormalImpliedVol::compute(price, f, k, t, WasmOptionType::Put).unwrap();
+    assert!((iv - sigma).abs() < 1e-10, "normal put iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn displaced_iv_round_trip_call() {
+    let (f, k, t, sigma, beta) = (100.0, 100.0, 1.0, 0.20, 0.5);
+    let price = displaced_price(f, k, sigma, t, beta, WasmOptionType::Call).unwrap();
+    let calc = WasmDisplacedImpliedVol::new(beta).unwrap();
+    assert!(
+        (calc.beta() - beta).abs() < 1e-15,
+        "beta getter={}",
+        calc.beta()
+    );
+    let iv = calc.compute(price, f, k, t, WasmOptionType::Call).unwrap();
+    assert!((iv - sigma).abs() < 1e-10, "displaced call iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn displaced_iv_round_trip_put() {
+    let (f, k, t, sigma, beta) = (100.0, 90.0, 1.0, 0.20, 0.5);
+    let price = displaced_price(f, k, sigma, t, beta, WasmOptionType::Put).unwrap();
+    let calc = WasmDisplacedImpliedVol::new(beta).unwrap();
+    let iv = calc.compute(price, f, k, t, WasmOptionType::Put).unwrap();
+    assert!((iv - sigma).abs() < 1e-10, "displaced put iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn displaced_beta_one_equals_black() {
+    // At beta = 1.0 displaced diffusion collapses to Black: a Black price
+    // recovers its input sigma through the beta=1.0 displaced calculator.
+    let (f, k, t, sigma) = (100.0, 110.0, 1.0, 0.25);
+    let price = black_price(f, k, sigma, t, WasmOptionType::Call).unwrap();
+    let calc = WasmDisplacedImpliedVol::new(1.0).unwrap();
+    let iv = calc.compute(price, f, k, t, WasmOptionType::Call).unwrap();
+    assert!((iv - sigma).abs() < 1e-12, "displaced(beta=1) iv={iv}");
+}
+
+#[wasm_bindgen_test]
+fn displaced_rejects_beta_out_of_range() {
+    assert!(WasmDisplacedImpliedVol::new(1.1).is_err());
+    assert!(WasmDisplacedImpliedVol::new(-0.1).is_err());
+}
+
+// ── Conventions known-values (mirrors src/conventions.rs + test_implied.py) ──
+
+#[wasm_bindgen_test]
+fn convention_known_values() {
+    assert!(
+        log_moneyness(100.0, 100.0).unwrap().abs() < 1e-12,
+        "log_moneyness ATM"
+    );
+    assert!(
+        (moneyness(120.0, 100.0).unwrap() - 1.2).abs() < 1e-12,
+        "moneyness 120/100"
+    );
+    assert!(
+        (moneyness(100.0, 100.0).unwrap() - 1.0).abs() < 1e-12,
+        "moneyness ATM"
+    );
+    // 100 * e^0.05 = 105.127109637602 (same literal as src/conventions.rs test)
+    let fwd = forward_price(100.0, 0.05, 0.0, 1.0).unwrap();
+    assert!(
+        (fwd - 105.127109637602).abs() < 1e-10,
+        "forward_price={fwd}"
+    );
+    assert!((forward_price(100.0, 0.0, 0.0, 1.0).unwrap() - 100.0).abs() < 1e-12);
+}
+
+#[wasm_bindgen_test]
+fn convention_error_paths() {
+    assert!(log_moneyness(100.0, 0.0).is_err());
+    assert!(log_moneyness(0.0, 100.0).is_err());
+    assert!(forward_price(0.0, 0.05, 0.0, 1.0).is_err());
+    assert!(forward_price(100.0, 0.05, 0.0, -1.0).is_err());
+}
+
+// ── Local vol: Dupire + boundary adapter, reachable from WASM surfaces (PAN-28) ──
+
+// A perfectly flat cubic-spline surface (constant 0.20 vol at every strike and
+// tenor) reproduces the core FlatVolSurface invariant: σ_loc ≡ σ exactly, since
+// all strike derivatives vanish and total variance is linear in t.
+fn flat_spline_surface() -> WasmPiecewiseSurface {
+    let strikes = vec![80.0, 90.0, 100.0, 110.0, 120.0];
+    let vols = vec![0.20, 0.20, 0.20, 0.20, 0.20];
+    let mut builder = WasmSurfaceBuilder::new();
+    builder.spot(100.0).unwrap();
+    builder.rate(0.05).unwrap();
+    builder.model_cubic_spline().unwrap();
+    builder
+        .add_tenor(0.5, strikes.clone(), vols.clone())
+        .unwrap();
+    builder.add_tenor(1.0, strikes, vols).unwrap();
+    builder.build().unwrap()
+}
+
+#[wasm_bindgen_test]
+fn local_vol_flat_surface_equals_sigma() {
+    let surface = flat_spline_surface();
+    let lv = surface.dupire_local_vol(None).unwrap();
+    // Interior point, away from tenor edges; flat surface => σ_loc == σ.
+    let v = lv.local_vol(0.75, 100.0).unwrap();
+    assert!((v - 0.20).abs() < 1e-10, "flat σ_loc={v}");
+}
+
+#[wasm_bindgen_test]
+fn local_vol_reachable_from_ssvi() {
+    let surf = WasmSsviSurface::new(
+        -0.3,
+        1.5,
+        0.5,
+        vec![0.25, 0.5, 1.0],
+        vec![100.0, 100.0, 100.0],
+        vec![0.01, 0.025, 0.06],
+    )
+    .unwrap();
+    let v = surf
+        .dupire_local_vol(None)
+        .unwrap()
+        .local_vol(0.5, 100.0)
+        .unwrap();
+    assert!(v > 0.0 && v < 1.0, "ssvi σ_loc={v}");
+    // Boundary adapter is also reachable from SSVI.
+    let vb = surf
+        .dupire_local_vol_with_boundary(None)
+        .unwrap()
+        .local_vol(0.5, 100.0)
+        .unwrap();
+    assert!(vb > 0.0 && vb < 1.0, "ssvi boundary σ_loc={vb}");
+}
+
+#[wasm_bindgen_test]
+fn boundary_rescues_t0_where_raw_errors() {
+    // THE PAN-25 boundary: strict Dupire rejects t = 0; the boundary adapter
+    // clamps to the floor (default bump 0.01) and succeeds.
+    let surface = flat_spline_surface();
+    let raw = surface.dupire_local_vol(None).unwrap();
+    assert!(
+        raw.local_vol(0.0, 100.0).is_err(),
+        "strict path should reject t=0"
+    );
+    let bdy = surface.dupire_local_vol_with_boundary(None).unwrap();
+    let v = bdy.local_vol(0.0, 100.0).unwrap();
+    assert!((v - 0.20).abs() < 1e-10, "boundary t=0 rescued σ_loc={v}");
 }

--- a/wasm/tests/smoke.rs
+++ b/wasm/tests/smoke.rs
@@ -376,7 +376,7 @@ fn too_few_points_rejected() {
 
 #[wasm_bindgen_test]
 fn version_returns_string() {
-    assert_eq!(version(), "2.2.0");
+    assert_eq!(version(), "2.3.0");
 }
 
 // ── is_arbitrage_free on smiles ──


### PR DESCRIPTION
Brings `volsurf-wasm` to coverage parity with `volsurf-python`. **No core `src/` code changed** — the gap was purely missing bindings (`git diff main -- src/` is empty).

Closes PAN-28.

## What's added

- **Implied vol** (`wasm/src/implied.rs`): `WasmOptionType { Call, Put }`; `blackPrice`/`normalPrice`/`displacedPrice`; `WasmBlackImpliedVol`/`WasmNormalImpliedVol` (static `compute`) and `WasmDisplacedImpliedVol` (instance, with `beta`).
- **Conventions**: `logMoneyness`, `moneyness`, `forwardPrice` (bundled in `implied.rs`, mirroring the Python layer).
- **Local vol** (`wasm/src/local_vol.rs`): `WasmDupireLocalVol` and `WasmBoundaryLocalVol` (the v2.2/PAN-25 small-time boundary adapter), reachable from any surface via `dupireLocalVol(bumpSize?)` / `dupireLocalVolWithBoundary(bumpSize?)` on `WasmSsviSurface`, `WasmEssviSurface`, `WasmPiecewiseSurface`.

## Key design decision

WASM has no unified surface type (unlike Python's `PySurface`), and wasm-bindgen permits neither trait-object params nor fn overloading. So local-vol access is a **method on each surface type**, each producing an `Arc<dyn VolSurface>` (Piecewise `Arc::clone`; SSVI/eSSVI `Arc::new(inner.clone())`).

## Versioning

Lockstep bump of all three crates (core, `volsurf-python`, `volsurf-wasm`) to **2.3.0**, keeping them version-synced per the PAN-25 precedent. Core `src/` is byte-identical in this release.

## Tests

- **78/78 wasm tests pass under `wasm-pack test --node`**, including the flat-surface `σ_loc ≡ σ` (1e-10) invariant and the `t=0` boundary rescue. (Native `cargo test` runs 0 of these — `#[wasm_bindgen_test]` needs a wasm runtime; CI only build/clippy-checks the wasm target.)
- 883 core lib tests pass; clippy `-D warnings` clean (incl. tests); fmt clean; host + `wasm32-unknown-unknown` build clean.
- Also fixed a stale pre-existing `version_returns_string` assertion (`2.1.0` → `2.3.0`), surfaced by being the first to run the wasm suite under a runtime.

## Commits (recommend squash on merge, per repo convention)

- feat: implied vol + conventions bindings
- feat: Dupire + boundary local vol bindings
- test: WASM smoke tests
- chore: docs + lockstep 2.3.0 bump