### PR TITLE
ci: run WASM tests in CI via wasm-pack test --node (PAN-41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,12 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
       - run: cargo build -p volsurf-wasm --target wasm32-unknown-unknown
       - run: cargo clippy -p volsurf-wasm --target wasm32-unknown-unknown -- -D warnings
+      - run: wasm-pack test --node wasm/
 
   doc:
     name: Documentation


### PR DESCRIPTION
## Problem

The `wasm` CI job only **built** and **clippy-linted** the bindings — it never **executed** them. `cargo test` registers 0 `#[wasm_bindgen_test]` tests on the host, so the ~78 PAN-28 smoke tests (price→IV round-trips, convention known-values, flat-surface σ_loc≡σ, the t=0 `BoundaryLocalVol` rescue) were written but never run in CI. A WASM binding regression would pass CI silently — the one real correctness gap in the test story.

## Fix

Wire the existing suite into the `wasm` job (one file, +4 lines):

```yaml
      - uses: Swatinem/rust-cache@v2
      - uses: taiki-e/install-action@v2
        with:
          tool: wasm-pack
      - run: cargo build -p volsurf-wasm --target wasm32-unknown-unknown
      - run: cargo clippy -p volsurf-wasm --target wasm32-unknown-unknown -- -D warnings
      - run: wasm-pack test --node wasm/
```

- `taiki-e/install-action@v2` pulls a prebuilt `wasm-pack` (seconds, vs a slow `cargo install`).
- `--node` runner: `smoke.rs` has no `run_in_browser` config; node is correct and sufficient (ubuntu-latest ships Node).
- Existing `cargo build` + `cargo clippy -- -D warnings` retained as an independent lint gate.
- No trigger change — the workflow already runs on `pull_request` + `push:[main]`.

No `src/`, `python/`, or `wasm/src/` changes — purely CI wiring of an existing suite.

## Verification

- **AC-1** `wasm-pack test --node wasm/` → `78 passed; 0 failed`.
- **AC-2** deliberately broke the version guard (`smoke.rs:379`) → suite went RED (`version_returns_string ... FAIL`, `77 passed; 1 failed`), then reverted; clean tree confirmed and re-ran green. Proves a binding regression now fails the job.
- **AC-3** runs on PRs to `main` (pre-existing trigger).
- Full local gate green: `cargo fmt --check`, `cargo clippy --all-features -D warnings`, `cargo test --all-features` (883 core + all suites pass).

## Acceptance criteria

- [x] CI executes the WASM smoke tests (not just build + clippy)
- [x] A deliberately broken WASM binding fails the `wasm` job
- [x] Job runs on PRs to `main`

Closes PAN-41.

---

**Recommend squash-merge** (single atomic CI change).